### PR TITLE
Fix redundant planner status return

### DIFF
--- a/gbplanner/src/gbplanner.cpp
+++ b/gbplanner/src/gbplanner.cpp
@@ -209,7 +209,7 @@ Gbplanner::PlannerStatus Gbplanner::getPlannerStatus() {
   if (planner_status_ == Gbplanner::PlannerStatus::READY)
     return Gbplanner::PlannerStatus::READY;
 
-  return Gbplanner::PlannerStatus::READY;
+  return Gbplanner::PlannerStatus::NOT_READY;
 }
 
 }  // namespace explorer


### PR DESCRIPTION
The `getPlannerStatus()` should return NOT_READY when the `if (planner_status_ == Gbplanner::PlannerStatus::READY)`  block does not execute