### PR TITLE
Feat/am multi robot setup

### DIFF
--- a/gbplanner/CMakeLists.txt
+++ b/gbplanner/CMakeLists.txt
@@ -26,5 +26,14 @@ cs_add_library(
 cs_add_executable(gbplanner_node src/gbplanner_ros_node.cpp)
 target_link_libraries(gbplanner_node ${PROJECT_NAME} ${planner_common_LIBRARIES})
 
+# Install Python scripts (standard CMake install, should work with catkin_simple)
+install(PROGRAMS
+  scripts/spawn_robots.py
+  scripts/spawn_model_direct.py
+  scripts/spawn_model_direct_wrapper.py
+  scripts/generate_multi_robot_rviz.py
+  DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+)
+
 cs_install()
 cs_export(LIBRARIES)

--- a/gbplanner/config/rmf_obelix/gbplanner_config.yaml
+++ b/gbplanner/config/rmf_obelix/gbplanner_config.yaml
@@ -116,6 +116,7 @@ RandomSamplerParams:
 PlanningParams:
   type:             kBasicExploration #kAdaptiveExploration, kBasicExploration
   rr_mode:          kGraph
+  global_frame_id:  world  # Global frame for visualization and planning (must be "world" for multi-robot)
   exp_sensor_list:  ["OS064"]
   # no_gain_zones_list: ["g1"]
   v_max:            1.0 # max velocity m/s
@@ -137,7 +138,7 @@ PlanningParams:
   exp_gain_voxel_size: 0.8 # used if use_ray_model_for_volumetric_gain is false
   # Gains:
   path_length_penalty: 0.04
-  path_direction_penalty: 0.1
+  path_direction_penalty: 0.05  # Reduced from 0.1 to reduce oscillation (lower = less penalty for non-forward paths)
   occupied_voxel_gain: 0.0
   free_voxel_gain:  0.0 # prefer directions towards more free voxels in case of the dead-end
   unknown_voxel_gain: 60.0
@@ -154,6 +155,7 @@ PlanningParams:
   path_interpolation_distance: 0.5
   
   time_budget_limit: 480 # seconds
+  auto_global_planner_enable: true  # Enable global planner to escape local minima (triggers after 4 consecutive iterations with no frontiers)
   auto_homing_enable: true
   go_home_if_fully_explored: true
 

--- a/gbplanner/config/robots.yaml
+++ b/gbplanner/config/robots.yaml
@@ -22,11 +22,11 @@ robots:
     z: 0.5
   
   # Uncomment to add more robots:
-  # - name: rmf_obelix_3
-  #   base_name: rmf_obelix
-  #   x: 10.0
-  #   y: 0.0
-  #   z: 0.5
+  - name: rmf_obelix_3
+    base_name: rmf_obelix
+    x: 10.0
+    y: 0.0
+    z: 0.5
 
 
 

--- a/gbplanner/config/robots.yaml
+++ b/gbplanner/config/robots.yaml
@@ -1,0 +1,34 @@
+# Multi-Robot Configuration File
+# This file defines the robots to be spawned in the simulation.
+# Each robot will run the entire GBPlanner stack independently with proper namespacing.
+#
+# Format:
+#   robots: List of robot configurations
+#     - name: Unique robot name (used for namespacing topics, services, nodes)
+#       base_name: Base name for config directory (e.g., "rmf_obelix" uses config/rmf_obelix/)
+#       x, y, z: Initial spawn position in Gazebo world (meters)
+
+robots:
+  - name: rmf_obelix_1
+    base_name: rmf_obelix
+    x: 0.0
+    y: 0.0
+    z: 0.5
+  
+  - name: rmf_obelix_2
+    base_name: rmf_obelix
+    x: 5.0
+    y: 0.0
+    z: 0.5
+  
+  # Uncomment to add more robots:
+  # - name: rmf_obelix_3
+  #   base_name: rmf_obelix
+  #   x: 10.0
+  #   y: 0.0
+  #   z: 0.5
+
+
+
+
+

--- a/gbplanner/config/rviz/rmf_obelix.rviz
+++ b/gbplanner/config/rviz/rmf_obelix.rviz
@@ -868,6 +868,62 @@ Visualization Manager:
           Use Fixed Frame: true
           Use rainbow: true
           Value: true
+        - Alpha: 1
+          Autocompute Intensity Bounds: true
+          Autocompute Value Bounds:
+            Max Value: 2.2908499240875244
+            Min Value: -2.061321496963501
+            Value: true
+          Axis: Z
+          Channel Name: intensity
+          Class: rviz/PointCloud2
+          Color: 255; 255; 255
+          Color Transformer: AxisColor
+          Decay Time: 0
+          Enabled: true
+          Invert Rainbow: false
+          Max Color: 255; 255; 255
+          Min Color: 0; 0; 0
+          Name: Robot3_VLP
+          Position Transformer: XYZ
+          Queue Size: 10
+          Selectable: true
+          Size (Pixels): 1
+          Size (m): 0.009999999776482582
+          Style: Points
+          Topic: /rmf_obelix_3/velodyne_points
+          Unreliable: false
+          Use Fixed Frame: true
+          Use rainbow: true
+          Value: true
+        - Alpha: 1
+          Autocompute Intensity Bounds: true
+          Autocompute Value Bounds:
+            Max Value: 2.2908499240875244
+            Min Value: -2.061321496963501
+            Value: true
+          Axis: Z
+          Channel Name: intensity
+          Class: rviz/PointCloud2
+          Color: 255; 255; 255
+          Color Transformer: AxisColor
+          Decay Time: 0
+          Enabled: true
+          Invert Rainbow: false
+          Max Color: 255; 255; 255
+          Min Color: 0; 0; 0
+          Name: Robot4_VLP
+          Position Transformer: XYZ
+          Queue Size: 10
+          Selectable: true
+          Size (Pixels): 1
+          Size (m): 0.009999999776482582
+          Style: Points
+          Topic: /rmf_obelix_4/velodyne_points
+          Unreliable: false
+          Use Fixed Frame: true
+          Use rainbow: true
+          Value: true
         - Angle Tolerance: 0.10000000149011612
           Class: rviz/Odometry
           Covariance:
@@ -901,6 +957,76 @@ Visualization Manager:
             Shaft Radius: 0.20000000298023224
             Value: Arrow
           Topic: /rmf_obelix_2/ground_truth/odometry_throttled
+          Unreliable: false
+          Value: true
+        - Angle Tolerance: 0.10000000149011612
+          Class: rviz/Odometry
+          Covariance:
+            Orientation:
+              Alpha: 0.5
+              Color: 255; 255; 127
+              Color Style: Unique
+              Frame: Local
+              Offset: 1
+              Scale: 1
+              Value: true
+            Position:
+              Alpha: 0.30000001192092896
+              Color: 204; 51; 204
+              Scale: 1
+              Value: true
+            Value: false
+          Enabled: true
+          Keep: 1
+          Name: Robot3_Odometry
+          Position Tolerance: 0.10000000149011612
+          Queue Size: 10
+          Shape:
+            Alpha: 1
+            Axes Length: 1
+            Axes Radius: 0.10000000149011612
+            Color: 0; 128; 255
+            Head Length: 0.20000000298023224
+            Head Radius: 0.4000000059604645
+            Shaft Length: 1
+            Shaft Radius: 0.20000000298023224
+            Value: Arrow
+          Topic: /rmf_obelix_3/ground_truth/odometry_throttled
+          Unreliable: false
+          Value: true
+        - Angle Tolerance: 0.10000000149011612
+          Class: rviz/Odometry
+          Covariance:
+            Orientation:
+              Alpha: 0.5
+              Color: 255; 255; 127
+              Color Style: Unique
+              Frame: Local
+              Offset: 1
+              Scale: 1
+              Value: true
+            Position:
+              Alpha: 0.30000001192092896
+              Color: 204; 51; 204
+              Scale: 1
+              Value: true
+            Value: false
+          Enabled: true
+          Keep: 1
+          Name: Robot4_Odometry
+          Position Tolerance: 0.10000000149011612
+          Queue Size: 10
+          Shape:
+            Alpha: 1
+            Axes Length: 1
+            Axes Radius: 0.10000000149011612
+            Color: 255; 255; 0
+            Head Length: 0.20000000298023224
+            Head Radius: 0.4000000059604645
+            Shaft Length: 1
+            Shaft Radius: 0.20000000298023224
+            Value: Arrow
+          Topic: /rmf_obelix_4/ground_truth/odometry_throttled
           Unreliable: false
           Value: true
       Enabled: true

--- a/gbplanner/config/rviz/rmf_obelix.rviz
+++ b/gbplanner/config/rviz/rmf_obelix.rviz
@@ -67,27 +67,35 @@ Visualization Manager:
     - Class: rviz/Group
       Displays:
         - Class: rviz/TF
-          Enabled: false
+          Enabled: true
           Frame Timeout: 15
           Frames:
-            All Enabled: false
+            All Enabled: true
           Marker Alpha: 1
           Marker Scale: 20
           Name: TF
           Show Arrows: true
           Show Axes: true
-          Show Names: false
+          Show Names: true
           Tree:
             {}
           Update Interval: 0
-          Value: false
+          Value: true
         - Alpha: 1
           Class: rviz/Axes
           Enabled: true
           Length: 3
-          Name: BaseLink
+          Name: Robot1_BaseLink
           Radius: 0.20000000298023224
-          Reference Frame: rmf_obelix/base_link
+          Reference Frame: rmf_obelix_1/base_link
+          Value: true
+        - Alpha: 1
+          Class: rviz/Axes
+          Enabled: true
+          Length: 3
+          Name: Robot2_BaseLink
+          Radius: 0.20000000298023224
+          Reference Frame: rmf_obelix_2/base_link
           Value: true
         - Alpha: 1
           Class: rviz/Axes
@@ -131,14 +139,14 @@ Visualization Manager:
         Shaft Length: 1
         Shaft Radius: 0.20000000298023224
         Value: Arrow
-      Topic: /ground_truth/odometry_throttled
+      Topic: /rmf_obelix_1/ground_truth/odometry_throttled
       Unreliable: false
       Value: true
     - Class: rviz/Group
       Displays:
         - Class: rviz/MarkerArray
           Enabled: false
-          Marker Topic: /vis/planning_failed
+          Marker Topic: /rmf_obelix_1/vis/planning_failed
           Name: PlanningFailed
           Namespaces:
             {}
@@ -146,7 +154,7 @@ Visualization Manager:
           Value: false
         - Class: rviz/MarkerArray
           Enabled: false
-          Marker Topic: /vis/volumetric_gains
+          Marker Topic: /rmf_obelix_1/vis/volumetric_gains
           Name: VolumetricGain
           Namespaces:
             {}
@@ -154,7 +162,7 @@ Visualization Manager:
           Value: false
         - Class: rviz/MarkerArray
           Enabled: false
-          Marker Topic: /vis/sensor_fov
+          Marker Topic: /rmf_obelix_1/vis/sensor_fov
           Name: SensorFOV
           Namespaces:
             {}
@@ -162,7 +170,7 @@ Visualization Manager:
           Value: false
         - Class: rviz/MarkerArray
           Enabled: true
-          Marker Topic: /vis/best_planning_paths
+          Marker Topic: /rmf_obelix_1/vis/best_planning_paths
           Name: BestPaths
           Namespaces:
             best_path: true
@@ -171,7 +179,7 @@ Visualization Manager:
           Value: true
         - Class: rviz/MarkerArray
           Enabled: true
-          Marker Topic: /vis/shortest_paths
+          Marker Topic: /rmf_obelix_1/vis/shortest_paths
           Name: ShortestPaths
           Namespaces:
             best_leaf_vertices: false
@@ -185,7 +193,7 @@ Visualization Manager:
           Value: true
         - Class: rviz/MarkerArray
           Enabled: true
-          Marker Topic: /vis/robot_state
+          Marker Topic: /rmf_obelix_1/vis/robot_state
           Name: RobotState
           Namespaces:
             extension: true
@@ -196,7 +204,7 @@ Visualization Manager:
           Value: true
         - Class: rviz/MarkerArray
           Enabled: false
-          Marker Topic: /vis/planning_workspace
+          Marker Topic: /rmf_obelix_1/vis/planning_workspace
           Name: PlanningWorkspace
           Namespaces:
             {}
@@ -204,7 +212,7 @@ Visualization Manager:
           Value: false
         - Class: rviz/MarkerArray
           Enabled: false
-          Marker Topic: /vis/planning_global_graph
+          Marker Topic: /rmf_obelix_1/vis/planning_global_graph
           Name: GlobalGraph
           Namespaces:
             {}
@@ -212,7 +220,7 @@ Visualization Manager:
           Value: false
         - Class: rviz/MarkerArray
           Enabled: false
-          Marker Topic: /vis/planning_homing_path
+          Marker Topic: /rmf_obelix_1/vis/planning_homing_path
           Name: HomingPath
           Namespaces:
             {}
@@ -220,7 +228,7 @@ Visualization Manager:
           Value: false
         - Class: rviz/MarkerArray
           Enabled: true
-          Marker Topic: /vis/planning_graph
+          Marker Topic: /rmf_obelix_1/vis/planning_graph
           Name: PlanningGraph
           Namespaces:
             edges: false
@@ -229,7 +237,7 @@ Visualization Manager:
           Value: true
         - Class: rviz/MarkerArray
           Enabled: false
-          Marker Topic: /vis/sampler
+          Marker Topic: /rmf_obelix_1/vis/sampler
           Name: Sampler
           Namespaces:
             {}
@@ -237,7 +245,7 @@ Visualization Manager:
           Value: false
         - Class: rviz/MarkerArray
           Enabled: true
-          Marker Topic: /vis/ref_path
+          Marker Topic: /rmf_obelix_1/vis/ref_path
           Name: RefPath
           Namespaces:
             ref_path: true
@@ -246,7 +254,7 @@ Visualization Manager:
           Value: true
         - Class: rviz/MarkerArray
           Enabled: false
-          Marker Topic: /vis/ray_casting
+          Marker Topic: /rmf_obelix_1/vis/ray_casting
           Name: RayCasting
           Namespaces:
             {}
@@ -254,7 +262,7 @@ Visualization Manager:
           Value: false
         - Class: rviz/MarkerArray
           Enabled: false
-          Marker Topic: /vis/shortest_path_clustering
+          Marker Topic: /rmf_obelix_1/vis/shortest_path_clustering
           Name: ShortestPathsClustering
           Namespaces:
             {}
@@ -262,7 +270,7 @@ Visualization Manager:
           Value: false
         - Class: rviz/MarkerArray
           Enabled: false
-          Marker Topic: /vis/state_history
+          Marker Topic: /rmf_obelix_1/vis/state_history
           Name: StateHist
           Namespaces:
             {}
@@ -270,7 +278,7 @@ Visualization Manager:
           Value: false
         - Class: rviz/MarkerArray
           Enabled: true
-          Marker Topic: /vis/planning_global_path
+          Marker Topic: /rmf_obelix_1/vis/planning_global_path
           Name: PlanningGlobalPath
           Namespaces:
             {}
@@ -278,7 +286,7 @@ Visualization Manager:
           Value: true
         - Class: rviz/MarkerArray
           Enabled: true
-          Marker Topic: /vis/no_gain_zone
+          Marker Topic: /rmf_obelix_1/vis/no_gain_zone
           Name: NoGainZone
           Namespaces:
             {}
@@ -286,7 +294,7 @@ Visualization Manager:
           Value: true
         - Class: rviz/Marker
           Enabled: true
-          Marker Topic: /gbplanner/go_to_waypoint_pose_visualization
+          Marker Topic: /rmf_obelix_1/gbplanner/go_to_waypoint_pose_visualization
           Name: GoToWaypointVis
           Namespaces:
             {}
@@ -331,12 +339,75 @@ Visualization Manager:
           Size (Pixels): 1
           Size (m): 0.009999999776482582
           Style: Points
-          Topic: /rmf_obelix/velodyne_points
+          Topic: /rmf_obelix_1/velodyne_points
           Unreliable: false
           Use Fixed Frame: true
           Use rainbow: true
           Value: true
-      Enabled: false
+        - Alpha: 1
+          Autocompute Intensity Bounds: true
+          Autocompute Value Bounds:
+            Max Value: 2.2908499240875244
+            Min Value: -2.061321496963501
+            Value: true
+          Axis: Z
+          Channel Name: intensity
+          Class: rviz/PointCloud2
+          Color: 255; 255; 255
+          Color Transformer: AxisColor
+          Decay Time: 0
+          Enabled: true
+          Invert Rainbow: false
+          Max Color: 255; 255; 255
+          Min Color: 0; 0; 0
+          Name: Robot2_VLP
+          Position Transformer: XYZ
+          Queue Size: 10
+          Selectable: true
+          Size (Pixels): 1
+          Size (m): 0.009999999776482582
+          Style: Points
+          Topic: /rmf_obelix_2/velodyne_points
+          Unreliable: false
+          Use Fixed Frame: true
+          Use rainbow: true
+          Value: true
+        - Angle Tolerance: 0.10000000149011612
+          Class: rviz/Odometry
+          Covariance:
+            Orientation:
+              Alpha: 0.5
+              Color: 255; 255; 127
+              Color Style: Unique
+              Frame: Local
+              Offset: 1
+              Scale: 1
+              Value: true
+            Position:
+              Alpha: 0.30000001192092896
+              Color: 204; 51; 204
+              Scale: 1
+              Value: true
+            Value: false
+          Enabled: true
+          Keep: 1
+          Name: Robot2_Odometry
+          Position Tolerance: 0.10000000149011612
+          Queue Size: 10
+          Shape:
+            Alpha: 1
+            Axes Length: 1
+            Axes Radius: 0.10000000149011612
+            Color: 0; 255; 0
+            Head Length: 0.20000000298023224
+            Head Radius: 0.4000000059604645
+            Shaft Length: 1
+            Shaft Radius: 0.20000000298023224
+            Value: Arrow
+          Topic: /rmf_obelix_2/ground_truth/odometry_throttled
+          Unreliable: false
+          Value: true
+      Enabled: true
       Name: Sensors
     - Class: rviz/Group
       Displays:
@@ -344,12 +415,12 @@ Visualization Manager:
           Enabled: false
           Name: VoxbloxMesh
           Queue Size: 10
-          Topic: /gbplanner_node/mesh
+          Topic: /rmf_obelix_1/gbplanner_node/mesh
           Unreliable: false
           Value: false
         - Class: rviz/MarkerArray
           Enabled: false
-          Marker Topic: /gbplanner_node/occupied_nodes
+          Marker Topic: /rmf_obelix_1/gbplanner_node/occupied_nodes
           Name: Occupied
           Namespaces:
             {}
@@ -378,7 +449,7 @@ Visualization Manager:
           Size (Pixels): 3
           Size (m): 0.05000000074505806
           Style: Flat Squares
-          Topic: /gbplanner_node/tsdf_pointcloud
+          Topic: /rmf_obelix_1/gbplanner_node/tsdf_pointcloud
           Unreliable: false
           Use Fixed Frame: true
           Use rainbow: true
@@ -406,7 +477,7 @@ Visualization Manager:
           Size (Pixels): 1
           Size (m): 0.009999999776482582
           Style: Points
-          Topic: /gbplanner_node/surface_pointcloud
+          Topic: /rmf_obelix_1/gbplanner_node/surface_pointcloud
           Unreliable: false
           Use Fixed Frame: true
           Use rainbow: true
@@ -466,7 +537,7 @@ Visualization Manager:
       Name: Current View
       Near Clip Distance: 0.009999999776482582
       Pitch: 0.8697964549064636
-      Target Frame: rmf_obelix/base_link
+      Target Frame: rmf_obelix_1/base_link
       Yaw: 3.615403413772583
     Saved: ~
 Window Geometry:

--- a/gbplanner/config/rviz/rmf_obelix.rviz
+++ b/gbplanner/config/rviz/rmf_obelix.rviz
@@ -67,7 +67,7 @@ Visualization Manager:
     - Class: rviz/Group
       Displays:
         - Class: rviz/TF
-          Enabled: true
+          Enabled: false
           Frame Timeout: 15
           Frames:
             All Enabled: true
@@ -80,7 +80,7 @@ Visualization Manager:
           Tree:
             {}
           Update Interval: 0
-          Value: true
+          Value: false
         - Alpha: 1
           Class: rviz/Axes
           Enabled: true
@@ -96,6 +96,22 @@ Visualization Manager:
           Name: Robot2_BaseLink
           Radius: 0.20000000298023224
           Reference Frame: rmf_obelix_2/base_link
+          Value: true
+        - Alpha: 1
+          Class: rviz/Axes
+          Enabled: true
+          Length: 3
+          Name: Robot3_BaseLink
+          Radius: 0.20000000298023224
+          Reference Frame: rmf_obelix_3/base_link
+          Value: true
+        - Alpha: 1
+          Class: rviz/Axes
+          Enabled: true
+          Length: 3
+          Name: Robot4_BaseLink
+          Radius: 0.20000000298023224
+          Reference Frame: rmf_obelix_4/base_link
           Value: true
         - Alpha: 1
           Class: rviz/Axes
@@ -301,7 +317,487 @@ Visualization Manager:
           Queue Size: 100
           Value: true
       Enabled: true
-      Name: PlannerViz
+      Name: PlannerViz_Robot1
+    - Class: rviz/Group
+      Displays:
+        - Class: rviz/MarkerArray
+          Enabled: false
+          Marker Topic: /rmf_obelix_2/vis/planning_failed
+          Name: PlanningFailed
+          Namespaces:
+            {}
+          Queue Size: 100
+          Value: false
+        - Class: rviz/MarkerArray
+          Enabled: false
+          Marker Topic: /rmf_obelix_2/vis/volumetric_gains
+          Name: VolumetricGain
+          Namespaces:
+            {}
+          Queue Size: 100
+          Value: false
+        - Class: rviz/MarkerArray
+          Enabled: false
+          Marker Topic: /rmf_obelix_2/vis/sensor_fov
+          Name: SensorFOV
+          Namespaces:
+            {}
+          Queue Size: 100
+          Value: false
+        - Class: rviz/MarkerArray
+          Enabled: true
+          Marker Topic: /rmf_obelix_2/vis/best_planning_paths
+          Name: BestPaths
+          Namespaces:
+            best_path: true
+            vertices: true
+          Queue Size: 100
+          Value: true
+        - Class: rviz/MarkerArray
+          Enabled: true
+          Marker Topic: /rmf_obelix_2/vis/shortest_paths
+          Name: ShortestPaths
+          Namespaces:
+            best_leaf_vertices: false
+            frontiers: true
+            gain: false
+            heading: false
+            leaf_vertices: false
+            shortest_edges: false
+            vertices: false
+          Queue Size: 100
+          Value: true
+        - Class: rviz/MarkerArray
+          Enabled: true
+          Marker Topic: /rmf_obelix_2/vis/robot_state
+          Name: RobotState
+          Namespaces:
+            extension: true
+            extension_aligned: true
+            heading: true
+            size: true
+          Queue Size: 100
+          Value: true
+        - Class: rviz/MarkerArray
+          Enabled: false
+          Marker Topic: /rmf_obelix_2/vis/planning_workspace
+          Name: PlanningWorkspace
+          Namespaces:
+            {}
+          Queue Size: 100
+          Value: false
+        - Class: rviz/MarkerArray
+          Enabled: false
+          Marker Topic: /rmf_obelix_2/vis/planning_global_graph
+          Name: GlobalGraph
+          Namespaces:
+            {}
+          Queue Size: 100
+          Value: false
+        - Class: rviz/MarkerArray
+          Enabled: false
+          Marker Topic: /rmf_obelix_2/vis/planning_homing_path
+          Name: HomingPath
+          Namespaces:
+            {}
+          Queue Size: 100
+          Value: false
+        - Class: rviz/MarkerArray
+          Enabled: true
+          Marker Topic: /rmf_obelix_2/vis/planning_graph
+          Name: PlanningGraph
+          Namespaces:
+            edges: false
+            vertices: true
+          Queue Size: 100
+          Value: true
+        - Class: rviz/MarkerArray
+          Enabled: false
+          Marker Topic: /rmf_obelix_2/vis/sampler
+          Name: Sampler
+          Namespaces:
+            {}
+          Queue Size: 100
+          Value: false
+        - Class: rviz/MarkerArray
+          Enabled: true
+          Marker Topic: /rmf_obelix_2/vis/ref_path
+          Name: RefPath
+          Namespaces:
+            ref_path: true
+            vertices: true
+          Queue Size: 100
+          Value: true
+        - Class: rviz/MarkerArray
+          Enabled: false
+          Marker Topic: /rmf_obelix_2/vis/ray_casting
+          Name: RayCasting
+          Namespaces:
+            {}
+          Queue Size: 100
+          Value: false
+        - Class: rviz/MarkerArray
+          Enabled: false
+          Marker Topic: /rmf_obelix_2/vis/shortest_path_clustering
+          Name: ShortestPathsClustering
+          Namespaces:
+            {}
+          Queue Size: 100
+          Value: false
+        - Class: rviz/MarkerArray
+          Enabled: false
+          Marker Topic: /rmf_obelix_2/vis/state_history
+          Name: StateHist
+          Namespaces:
+            {}
+          Queue Size: 100
+          Value: false
+        - Class: rviz/MarkerArray
+          Enabled: true
+          Marker Topic: /rmf_obelix_2/vis/planning_global_path
+          Name: PlanningGlobalPath
+          Namespaces:
+            {}
+          Queue Size: 100
+          Value: true
+        - Class: rviz/MarkerArray
+          Enabled: true
+          Marker Topic: /rmf_obelix_2/vis/no_gain_zone
+          Name: NoGainZone
+          Namespaces:
+            {}
+          Queue Size: 100
+          Value: true
+        - Class: rviz/Marker
+          Enabled: true
+          Marker Topic: /rmf_obelix_2/gbplanner/go_to_waypoint_pose_visualization
+          Name: GoToWaypointVis
+          Namespaces:
+            {}
+          Queue Size: 100
+          Value: true
+      Enabled: true
+      Name: PlannerViz_Robot2
+    - Class: rviz/Group
+      Displays:
+        - Class: rviz/MarkerArray
+          Enabled: false
+          Marker Topic: /rmf_obelix_3/vis/planning_failed
+          Name: PlanningFailed
+          Namespaces:
+            {}
+          Queue Size: 100
+          Value: false
+        - Class: rviz/MarkerArray
+          Enabled: false
+          Marker Topic: /rmf_obelix_3/vis/volumetric_gains
+          Name: VolumetricGain
+          Namespaces:
+            {}
+          Queue Size: 100
+          Value: false
+        - Class: rviz/MarkerArray
+          Enabled: false
+          Marker Topic: /rmf_obelix_3/vis/sensor_fov
+          Name: SensorFOV
+          Namespaces:
+            {}
+          Queue Size: 100
+          Value: false
+        - Class: rviz/MarkerArray
+          Enabled: true
+          Marker Topic: /rmf_obelix_3/vis/best_planning_paths
+          Name: BestPaths
+          Namespaces:
+            best_path: true
+            vertices: true
+          Queue Size: 100
+          Value: true
+        - Class: rviz/MarkerArray
+          Enabled: true
+          Marker Topic: /rmf_obelix_3/vis/shortest_paths
+          Name: ShortestPaths
+          Namespaces:
+            best_leaf_vertices: false
+            frontiers: true
+            gain: false
+            heading: false
+            leaf_vertices: false
+            shortest_edges: false
+            vertices: false
+          Queue Size: 100
+          Value: true
+        - Class: rviz/MarkerArray
+          Enabled: true
+          Marker Topic: /rmf_obelix_3/vis/robot_state
+          Name: RobotState
+          Namespaces:
+            extension: true
+            extension_aligned: true
+            heading: true
+            size: true
+          Queue Size: 100
+          Value: true
+        - Class: rviz/MarkerArray
+          Enabled: false
+          Marker Topic: /rmf_obelix_3/vis/planning_workspace
+          Name: PlanningWorkspace
+          Namespaces:
+            {}
+          Queue Size: 100
+          Value: false
+        - Class: rviz/MarkerArray
+          Enabled: false
+          Marker Topic: /rmf_obelix_3/vis/planning_global_graph
+          Name: GlobalGraph
+          Namespaces:
+            {}
+          Queue Size: 100
+          Value: false
+        - Class: rviz/MarkerArray
+          Enabled: false
+          Marker Topic: /rmf_obelix_3/vis/planning_homing_path
+          Name: HomingPath
+          Namespaces:
+            {}
+          Queue Size: 100
+          Value: false
+        - Class: rviz/MarkerArray
+          Enabled: true
+          Marker Topic: /rmf_obelix_3/vis/planning_graph
+          Name: PlanningGraph
+          Namespaces:
+            edges: false
+            vertices: true
+          Queue Size: 100
+          Value: true
+        - Class: rviz/MarkerArray
+          Enabled: false
+          Marker Topic: /rmf_obelix_3/vis/sampler
+          Name: Sampler
+          Namespaces:
+            {}
+          Queue Size: 100
+          Value: false
+        - Class: rviz/MarkerArray
+          Enabled: true
+          Marker Topic: /rmf_obelix_3/vis/ref_path
+          Name: RefPath
+          Namespaces:
+            ref_path: true
+            vertices: true
+          Queue Size: 100
+          Value: true
+        - Class: rviz/MarkerArray
+          Enabled: false
+          Marker Topic: /rmf_obelix_3/vis/ray_casting
+          Name: RayCasting
+          Namespaces:
+            {}
+          Queue Size: 100
+          Value: false
+        - Class: rviz/MarkerArray
+          Enabled: false
+          Marker Topic: /rmf_obelix_3/vis/shortest_path_clustering
+          Name: ShortestPathsClustering
+          Namespaces:
+            {}
+          Queue Size: 100
+          Value: false
+        - Class: rviz/MarkerArray
+          Enabled: false
+          Marker Topic: /rmf_obelix_3/vis/state_history
+          Name: StateHist
+          Namespaces:
+            {}
+          Queue Size: 100
+          Value: false
+        - Class: rviz/MarkerArray
+          Enabled: true
+          Marker Topic: /rmf_obelix_3/vis/planning_global_path
+          Name: PlanningGlobalPath
+          Namespaces:
+            {}
+          Queue Size: 100
+          Value: true
+        - Class: rviz/MarkerArray
+          Enabled: true
+          Marker Topic: /rmf_obelix_3/vis/no_gain_zone
+          Name: NoGainZone
+          Namespaces:
+            {}
+          Queue Size: 100
+          Value: true
+        - Class: rviz/Marker
+          Enabled: true
+          Marker Topic: /rmf_obelix_3/gbplanner/go_to_waypoint_pose_visualization
+          Name: GoToWaypointVis
+          Namespaces:
+            {}
+          Queue Size: 100
+          Value: true
+      Enabled: true
+      Name: PlannerViz_Robot3
+    - Class: rviz/Group
+      Displays:
+        - Class: rviz/MarkerArray
+          Enabled: false
+          Marker Topic: /rmf_obelix_4/vis/planning_failed
+          Name: PlanningFailed
+          Namespaces:
+            {}
+          Queue Size: 100
+          Value: false
+        - Class: rviz/MarkerArray
+          Enabled: false
+          Marker Topic: /rmf_obelix_4/vis/volumetric_gains
+          Name: VolumetricGain
+          Namespaces:
+            {}
+          Queue Size: 100
+          Value: false
+        - Class: rviz/MarkerArray
+          Enabled: false
+          Marker Topic: /rmf_obelix_4/vis/sensor_fov
+          Name: SensorFOV
+          Namespaces:
+            {}
+          Queue Size: 100
+          Value: false
+        - Class: rviz/MarkerArray
+          Enabled: true
+          Marker Topic: /rmf_obelix_4/vis/best_planning_paths
+          Name: BestPaths
+          Namespaces:
+            best_path: true
+            vertices: true
+          Queue Size: 100
+          Value: true
+        - Class: rviz/MarkerArray
+          Enabled: true
+          Marker Topic: /rmf_obelix_4/vis/shortest_paths
+          Name: ShortestPaths
+          Namespaces:
+            best_leaf_vertices: false
+            frontiers: true
+            gain: false
+            heading: false
+            leaf_vertices: false
+            shortest_edges: false
+            vertices: false
+          Queue Size: 100
+          Value: true
+        - Class: rviz/MarkerArray
+          Enabled: true
+          Marker Topic: /rmf_obelix_4/vis/robot_state
+          Name: RobotState
+          Namespaces:
+            extension: true
+            extension_aligned: true
+            heading: true
+            size: true
+          Queue Size: 100
+          Value: true
+        - Class: rviz/MarkerArray
+          Enabled: false
+          Marker Topic: /rmf_obelix_4/vis/planning_workspace
+          Name: PlanningWorkspace
+          Namespaces:
+            {}
+          Queue Size: 100
+          Value: false
+        - Class: rviz/MarkerArray
+          Enabled: false
+          Marker Topic: /rmf_obelix_4/vis/planning_global_graph
+          Name: GlobalGraph
+          Namespaces:
+            {}
+          Queue Size: 100
+          Value: false
+        - Class: rviz/MarkerArray
+          Enabled: false
+          Marker Topic: /rmf_obelix_4/vis/planning_homing_path
+          Name: HomingPath
+          Namespaces:
+            {}
+          Queue Size: 100
+          Value: false
+        - Class: rviz/MarkerArray
+          Enabled: true
+          Marker Topic: /rmf_obelix_4/vis/planning_graph
+          Name: PlanningGraph
+          Namespaces:
+            edges: false
+            vertices: true
+          Queue Size: 100
+          Value: true
+        - Class: rviz/MarkerArray
+          Enabled: false
+          Marker Topic: /rmf_obelix_4/vis/sampler
+          Name: Sampler
+          Namespaces:
+            {}
+          Queue Size: 100
+          Value: false
+        - Class: rviz/MarkerArray
+          Enabled: true
+          Marker Topic: /rmf_obelix_4/vis/ref_path
+          Name: RefPath
+          Namespaces:
+            ref_path: true
+            vertices: true
+          Queue Size: 100
+          Value: true
+        - Class: rviz/MarkerArray
+          Enabled: false
+          Marker Topic: /rmf_obelix_4/vis/ray_casting
+          Name: RayCasting
+          Namespaces:
+            {}
+          Queue Size: 100
+          Value: false
+        - Class: rviz/MarkerArray
+          Enabled: false
+          Marker Topic: /rmf_obelix_4/vis/shortest_path_clustering
+          Name: ShortestPathsClustering
+          Namespaces:
+            {}
+          Queue Size: 100
+          Value: false
+        - Class: rviz/MarkerArray
+          Enabled: false
+          Marker Topic: /rmf_obelix_4/vis/state_history
+          Name: StateHist
+          Namespaces:
+            {}
+          Queue Size: 100
+          Value: false
+        - Class: rviz/MarkerArray
+          Enabled: true
+          Marker Topic: /rmf_obelix_4/vis/planning_global_path
+          Name: PlanningGlobalPath
+          Namespaces:
+            {}
+          Queue Size: 100
+          Value: true
+        - Class: rviz/MarkerArray
+          Enabled: true
+          Marker Topic: /rmf_obelix_4/vis/no_gain_zone
+          Name: NoGainZone
+          Namespaces:
+            {}
+          Queue Size: 100
+          Value: true
+        - Class: rviz/Marker
+          Enabled: true
+          Marker Topic: /rmf_obelix_4/gbplanner/go_to_waypoint_pose_visualization
+          Name: GoToWaypointVis
+          Namespaces:
+            {}
+          Queue Size: 100
+          Value: true
+      Enabled: true
+      Name: PlannerViz_Robot4
     - Class: rviz/Group
       Displays:
         - Class: rviz/Image

--- a/gbplanner/launch/rmf/rmf_robot.launch
+++ b/gbplanner/launch/rmf/rmf_robot.launch
@@ -79,7 +79,10 @@
   <group ns="$(arg robot_name)">
     <node pkg="gbplanner" type="gbplanner_node" name="gbplanner_node" output="screen" launch-prefix="$(arg launch_prefix)" respawn="true">
       <remap from="odometry" to="$(arg odometry_topic)" />
-      <remap from="/pointcloud" to="/$(arg robot_name)/velodyne_points" />
+      <!-- IMPORTANT: Use relative "pointcloud" not absolute "/pointcloud" when inside namespace group -->
+      <!-- Inside namespace, "pointcloud" resolves to /$(arg robot_name)/pointcloud -->
+      <!-- We remap it to the absolute velodyne topic -->
+      <remap from="pointcloud" to="/$(arg robot_name)/velodyne_points" />
       <!-- Services are automatically namespaced to $(arg robot_name)/gbplanner/* -->
       <rosparam command="load" file="$(arg gbplanner_config_file)" />
       <rosparam command="load" file="$(arg map_config_file)" />

--- a/gbplanner/launch/rmf/rmf_robot.launch
+++ b/gbplanner/launch/rmf/rmf_robot.launch
@@ -1,0 +1,100 @@
+<launch>
+  <!-- Single Robot Launch File (for Multi-Robot Setup)
+       This file launches a single robot instance with proper namespacing.
+       Used by rmf_sim_multi.launch (via spawn_robots.py) to spawn multiple robots.
+       Each robot runs in its own roslaunch subprocess with unique namespace.
+  -->
+  
+  <!-- Required arguments -->
+  <arg name="robot_name" />
+  <arg name="base_name" />
+  <arg name="robot_x" default="0.0"/>
+  <arg name="robot_y" default="0.0"/>
+  <arg name="robot_z" default="0.5"/>
+  <arg name="launch_prefix" default=""/>
+  <arg name="use_sim_time" default="true"/>
+
+  <!-- Config files - use base_name for config directory -->
+  <arg name="gbplanner_config_file" default="$(find gbplanner)/config/$(arg base_name)/gbplanner_config.yaml"/>
+  <arg name="pci_file" default="$(find gbplanner)/config/$(arg base_name)/planner_control_interface_sim_config.yaml"/>
+  <arg name="voxblox_config_file" default="$(find gbplanner)/config/$(arg base_name)/voxblox_sim_config.yaml"/>
+  <arg name="map_config_file" default="$(arg voxblox_config_file)"/>
+
+  <!-- Static TF Publishers - namespaced with robot_name -->
+  <!-- Note: Gazebo publishes world->model_name/base_link automatically when model is spawned -->
+  <!-- However, we need to ensure world frame exists for RViz Fixed Frame -->
+  <!-- The model spawns at (x, y, z) via Gazebo spawn service, and Gazebo handles the TF -->
+  
+  <!-- World frame (only publish once, check if it exists first) -->
+  <!-- This is published in rmf_sim_multi.launch, but adding here as backup -->
+  
+  <node pkg="tf" type="static_transform_publisher" name="$(arg robot_name)_tf_51" args="0.15 0 0.0 0.0 0.261 0.0 $(arg robot_name)/base_link $(arg robot_name)/vi_sensor/base_link 10" />
+  <node pkg="tf" type="static_transform_publisher" name="$(arg robot_name)_tf_1" args="0 0 0 0 0 0 $(arg robot_name)/vi_sensor/base_link $(arg robot_name)/fcu 1" />
+  <node pkg="tf" type="static_transform_publisher" name="$(arg robot_name)_tf_2" args="0.015 0.055 0.0065 -1.57 0.1 -1.57 $(arg robot_name)/fcu $(arg robot_name)/vi_sensor/camera_depth_optical_center_link 1" />
+  <node pkg="tf" type="static_transform_publisher" name="$(arg robot_name)_tf_3" args="0.015 0.055 0.0065 -1.57 0.1 -1.57 $(arg robot_name)/fcu $(arg robot_name)/vi_sensor/camera_left_link 1" />
+  <node pkg="tf" type="static_transform_publisher" name="$(arg robot_name)_tf_4" args="0.015 -0.055 0.0065 -1.57 0.1 -1.57 $(arg robot_name)/fcu $(arg robot_name)/vi_sensor/camera_right_link 1" />
+  <node pkg="tf" type="static_transform_publisher" name="$(arg robot_name)_tf_5" args="0 0 0.05 0.0 0.0 0.0 $(arg robot_name)/base_link $(arg robot_name)/velodyne 10" />
+
+  <!-- Robot-specific group namespace -->
+  <group ns="$(arg robot_name)">
+    <node name="img_throttler" type="throttle" pkg="topic_tools" args="messages vi_sensor/camera_depth/depth/points 5 vi_sensor/camera_depth/depth/points_throttled" />
+    <node name="odo_throttler" type="throttle" pkg="topic_tools" args="messages ground_truth/odometry 100 ground_truth/odometry_throttled" />
+
+    <!-- Spawn model directly with unique name to avoid conflicts -->
+    <!-- This processes the xacro with base_name (for file resolution) but spawns with robot_name (unique) -->
+    <!-- Note: Node is inside group namespace, so full name will be $(robot_name)/$(robot_name)_spawn_model -->
+    <!-- Use wrapper script which calls the actual script from source directory -->
+    <!-- Not required - other nodes will keep launch file alive even if spawn fails initially -->
+    <node name="$(arg robot_name)_spawn_model" 
+          pkg="gbplanner" 
+          type="spawn_model_direct_wrapper.py" 
+          args="$(arg base_name) $(arg robot_name) $(arg robot_x) $(arg robot_y) $(arg robot_z)" 
+          output="screen" 
+          required="false"
+          respawn="true"/>
+    
+    <!-- Note: spawn_mav.launch is NOT included here to avoid model name conflicts -->
+    <!-- The model is spawned directly above with unique name -->
+    <!-- Controllers and other components are launched separately below -->
+
+    <!-- Position controller  -->
+    <node name="lee_position_controller_node" pkg="rotors_control" type="lee_position_controller_node" output="screen" respawn="true">
+      <rosparam command="load" file="$(find rotors_gazebo)/resource/lee_controller_$(arg base_name).yaml" />
+      <rosparam command="load" file="$(find rotors_gazebo)/resource/$(arg base_name).yaml" />
+      <remap from="odometry" to="odometry_sensor1/odometry" />
+    </node>
+  </group>
+
+  <!-- Pose throttler - namespaced -->
+  <arg name="odometry_topic" default="$(arg robot_name)/ground_truth/odometry_throttled"/>
+  <node name="$(arg robot_name)_pose_throttler" type="throttle" pkg="topic_tools" args="messages $(arg robot_name)/ground_truth/pose_with_covariance 10 $(arg robot_name)/msf_core/pose" />
+  
+  <!-- Graph based planning -->
+  <!-- Note: Node is inside namespace group, so services are advertised at $(arg robot_name)/gbplanner/* -->
+  <!-- This matches the single-robot setup where gbplanner_node is in the robot namespace -->
+  <group ns="$(arg robot_name)">
+    <node pkg="gbplanner" type="gbplanner_node" name="gbplanner_node" output="screen" launch-prefix="$(arg launch_prefix)" respawn="true">
+      <remap from="odometry" to="$(arg odometry_topic)" />
+      <remap from="/pointcloud" to="/$(arg robot_name)/velodyne_points" />
+      <!-- Services are automatically namespaced to $(arg robot_name)/gbplanner/* -->
+      <rosparam command="load" file="$(arg gbplanner_config_file)" />
+      <rosparam command="load" file="$(arg map_config_file)" />
+    </node>
+  </group>
+
+  <!-- Planner and Control Interface - namespaced -->
+  <!-- Note: Node is inside namespace group, so services are advertised at $(arg robot_name)/pci_* -->
+  <!-- But we need to remap to absolute paths to match how gbplanner_node advertises services -->
+  <group ns="$(arg robot_name)">
+    <node pkg="pci_general" type="pci_general_ros_node" name="pci_general_ros_node" output="screen" respawn="true">
+      <remap from="command/trajectory" to="command/trajectory" />
+      <remap from="planner_server" to="/$(arg robot_name)/gbplanner" />
+      <remap from="planner_homing_server" to="/$(arg robot_name)/gbplanner/homing" />
+      <remap from="odometry" to="$(arg odometry_topic)"/>
+      <!-- Services are automatically namespaced to $(arg robot_name)/pci_* -->
+      <rosparam command="load" file="$(arg pci_file)" />
+    </node>
+  </group>
+
+</launch>
+

--- a/gbplanner/launch/rmf/rmf_robot.launch
+++ b/gbplanner/launch/rmf/rmf_robot.launch
@@ -66,7 +66,11 @@
   </group>
 
   <!-- Pose throttler - namespaced -->
-  <arg name="odometry_topic" default="$(arg robot_name)/ground_truth/odometry_throttled"/>
+  <!-- IMPORTANT: This file runs many nodes inside <group ns="$(arg robot_name)">.
+       If odometry_topic is relative AND already includes $(arg robot_name),
+       it gets double-prefixed (e.g. /rmf_obelix_1/rmf_obelix_1/ground_truth/odometry_throttled).
+       Make it absolute to avoid double namespacing. -->
+  <arg name="odometry_topic" default="/$(arg robot_name)/ground_truth/odometry_throttled"/>
   <node name="$(arg robot_name)_pose_throttler" type="throttle" pkg="topic_tools" args="messages $(arg robot_name)/ground_truth/pose_with_covariance 10 $(arg robot_name)/msf_core/pose" />
   
   <!-- Graph based planning -->

--- a/gbplanner/launch/rmf/rmf_sim.launch
+++ b/gbplanner/launch/rmf/rmf_sim.launch
@@ -1,30 +1,26 @@
 <launch>
+  <!-- Single-Robot GBPlanner Simulation Launch File
+       Original single-robot launch file.
+       Usage: roslaunch gbplanner rmf_sim.launch robot_name:=rmf_obelix
+       
+       For multi-robot setup, use: roslaunch gbplanner rmf_sim_multi.launch
+  -->
+  
   <!-- All settings -->
   <arg name="robot_name" default="rmf_obelix"/>
   <arg name="gazebo_gui_en" default="true"/>
   <arg name="use_sim_time" default="true"/>
   <arg name="rviz_en" default="true" />
   <arg name="launch_prefix" default=""/> <!-- gdb -ex run //args -->
+  <arg name="world_file" default="$(find planner_gazebo_sim)/worlds/outdoor_city.world"/>
+  <arg name="rviz_config_file" default="$(find gbplanner)/config/rviz/rmf_obelix.rviz"/>
+  
   <param name="use_sim_time" value="$(arg use_sim_time)"/>
 
-  <!-- Config files -->
-  <arg name="gbplanner_config_file" default="$(find gbplanner)/config/$(arg robot_name)/gbplanner_config.yaml"/>
-  <arg name="pci_file" default="$(find gbplanner)/config/$(arg robot_name)/planner_control_interface_sim_config.yaml"/>
-  <arg name="voxblox_config_file" default="$(find gbplanner)/config/$(arg robot_name)/voxblox_sim_config.yaml"/>
-  <arg name="map_config_file" default="$(arg voxblox_config_file)"/>
-  <!-- <arg name="world_file" default="$(find planner_gazebo_sim)/worlds/darpa_cave_01.world"/> -->
-  <arg name="world_file" default="$(find planner_gazebo_sim)/worlds/outdoor_city.world"/>
+  <!-- Static TF: world -> navigation -->
+  <node pkg="tf" type="static_transform_publisher" name="tf_world_navigation" args="0 0 0 0 0 0 world navigation 100" />
 
-  <!-- Static TF -->
-  <node pkg="tf" type="static_transform_publisher" name="tf_53" args="0 0 0 0 0 0 world navigation 100" />
-  <node pkg="tf" type="static_transform_publisher" name="tf_51" args="0.15 0 0.0 0.0 0.261 0.0 $(arg robot_name)/base_link $(arg robot_name)/vi_sensor/base_link 10" />
-  <node pkg="tf" type="static_transform_publisher" name="tf_1" args="0 0 0 0 0 0 $(arg robot_name)/vi_sensor/base_link fcu 1" />
-  <node pkg="tf" type="static_transform_publisher" name="tf_2" args="0.015 0.055 0.0065 -1.57 0.1 -1.57 fcu $(arg robot_name)/vi_sensor/camera_depth_optical_center_link 1" />
-  <node pkg="tf" type="static_transform_publisher" name="tf_3" args="0.015 0.055 0.0065 -1.57 0.1 -1.57 fcu $(arg robot_name)/vi_sensor/camera_left_link 1" />
-  <node pkg="tf" type="static_transform_publisher" name="tf_4" args="0.015 -0.055 0.0065 -1.57 0.1 -1.57 fcu $(arg robot_name)/vi_sensor/camera_right_link 1" />
-  <node pkg="tf" type="static_transform_publisher" name="tf_5" args="0 0 0.05 0.0 0.0 0.0 $(arg robot_name)/base_link $(arg robot_name)/$(arg robot_name)/velodyne 10" />
-
-  <!-- ROS Gazebo  -->
+  <!-- ROS Gazebo -->
   <env name="GAZEBO_MODEL_PATH" value="${GAZEBO_MODEL_PATH}:$(find planner_gazebo_sim)/models:$(find subt_cave_sim)/models"/>
   <include file="$(find gazebo_ros)/launch/empty_world.launch">
     <arg name="world_name" value="$(arg world_file)" />
@@ -34,6 +30,15 @@
     <arg name="verbose" value="false"/>
   </include>
 
+  <!-- Static TF Publishers for sensors -->
+  <node pkg="tf" type="static_transform_publisher" name="tf_51" args="0.15 0 0.0 0.0 0.261 0.0 $(arg robot_name)/base_link $(arg robot_name)/vi_sensor/base_link 10" />
+  <node pkg="tf" type="static_transform_publisher" name="tf_1" args="0 0 0 0 0 0 $(arg robot_name)/vi_sensor/base_link fcu 1" />
+  <node pkg="tf" type="static_transform_publisher" name="tf_2" args="0.015 0.055 0.0065 -1.57 0.1 -1.57 fcu $(arg robot_name)/vi_sensor/camera_depth_optical_center_link 1" />
+  <node pkg="tf" type="static_transform_publisher" name="tf_3" args="0.015 0.055 0.0065 -1.57 0.1 -1.57 fcu $(arg robot_name)/vi_sensor/camera_left_link 1" />
+  <node pkg="tf" type="static_transform_publisher" name="tf_4" args="0.015 -0.055 0.0065 -1.57 0.1 -1.57 fcu $(arg robot_name)/vi_sensor/camera_right_link 1" />
+  <node pkg="tf" type="static_transform_publisher" name="tf_5" args="0 0 0.05 0.0 0.0 0.0 $(arg robot_name)/base_link $(arg robot_name)/$(arg robot_name)/velodyne 10" />
+
+  <!-- Robot-specific group namespace -->
   <group ns="$(arg robot_name)">
     <node name="img_throttler" type="throttle" pkg="topic_tools" args="messages vi_sensor/camera_depth/depth/points 5 vi_sensor/camera_depth/depth/points_throttled" />
     <node name="odo_throttler" type="throttle" pkg="topic_tools" args="messages ground_truth/odometry 100 ground_truth/odometry_throttled" />
@@ -56,25 +61,31 @@
     </node>
   </group>
 
+  <!-- Pose throttler -->
   <arg name="odometry_topic" default="$(arg robot_name)/ground_truth/odometry_throttled"/>
   <node name="pose_throttler" type="throttle" pkg="topic_tools" args="messages $(arg robot_name)/ground_truth/pose_with_covariance 10 /msf_core/pose" />
+  
   <!-- Graph based planning -->
+  <!-- Note: Node is outside namespace group so services are advertised at global paths (/gbplanner/*) -->
   <node pkg="gbplanner" type="gbplanner_node" name="gbplanner_node" output="screen" launch-prefix="$(arg launch_prefix)">
     <remap from="odometry" to="$(arg odometry_topic)" />
     <remap from="/pointcloud" to="/$(arg robot_name)/velodyne_points" />
-    <rosparam command="load" file="$(arg gbplanner_config_file)" />
-    <rosparam command="load" file="$(arg map_config_file)" />
+    <rosparam command="load" file="$(find gbplanner)/config/$(arg robot_name)/gbplanner_config.yaml" />
+    <rosparam command="load" file="$(find gbplanner)/config/$(arg robot_name)/voxblox_sim_config.yaml" />
   </node>
 
   <!-- Planner and Control Interface -->
+  <!-- Note: Node is outside namespace group so services are advertised at global paths (/pci_*) -->
+  <!-- Service remaps use absolute paths to match global service advertisements -->
   <node pkg="pci_general" type="pci_general_ros_node" name="pci_general_ros_node" output="screen">
     <remap from="command/trajectory" to="$(arg robot_name)/command/trajectory" />
-    <remap from="planner_server" to="gbplanner" />
-    <remap from="planner_homing_server" to="gbplanner/homing" />
+    <remap from="planner_server" to="/gbplanner" />
+    <remap from="planner_homing_server" to="/gbplanner/homing" />
     <remap from="odometry" to="$(arg odometry_topic)"/>
-    <rosparam command="load" file="$(arg pci_file)" />
+    <rosparam command="load" file="$(find gbplanner)/config/$(arg robot_name)/planner_control_interface_sim_config.yaml" />
   </node>
 
-  <node pkg="rviz" type="rviz" name="gbplanner_ui" output="screen" args="-d $(find gbplanner)/config/rviz/rmf_obelix.rviz"/>
+  <!-- RViz -->
+  <node pkg="rviz" type="rviz" name="gbplanner_ui" output="screen" args="-d $(arg rviz_config_file)" if="$(arg rviz_en)"/>
 
 </launch>

--- a/gbplanner/launch/rmf/rmf_sim.launch
+++ b/gbplanner/launch/rmf/rmf_sim.launch
@@ -1,7 +1,7 @@
 <launch>
   <!-- All settings -->
   <arg name="robot_name" default="rmf_obelix"/>
-  <arg name="gazebo_gui_en" default="false"/>
+  <arg name="gazebo_gui_en" default="true"/>
   <arg name="use_sim_time" default="true"/>
   <arg name="rviz_en" default="true" />
   <arg name="launch_prefix" default=""/> <!-- gdb -ex run //args -->
@@ -13,7 +13,7 @@
   <arg name="voxblox_config_file" default="$(find gbplanner)/config/$(arg robot_name)/voxblox_sim_config.yaml"/>
   <arg name="map_config_file" default="$(arg voxblox_config_file)"/>
   <!-- <arg name="world_file" default="$(find planner_gazebo_sim)/worlds/darpa_cave_01.world"/> -->
-  <arg name="world_file" default="$(find planner_gazebo_sim)/worlds/darpa_subt_final_circuit.world"/>
+  <arg name="world_file" default="$(find planner_gazebo_sim)/worlds/outdoor_city.world"/>
 
   <!-- Static TF -->
   <node pkg="tf" type="static_transform_publisher" name="tf_53" args="0 0 0 0 0 0 world navigation 100" />

--- a/gbplanner/launch/rmf/rmf_sim_multi.launch
+++ b/gbplanner/launch/rmf/rmf_sim_multi.launch
@@ -1,0 +1,44 @@
+<launch>
+  <!-- Multi-Robot GBPlanner Simulation Launch File
+       Supports multiple robots configured via robots.yaml
+       Usage: roslaunch gbplanner rmf_sim_multi.launch
+  -->
+  
+  <!-- All settings -->
+  <arg name="robots_config_file" default="$(find gbplanner)/config/robots.yaml"/>
+  <arg name="gazebo_gui_en" default="true"/>
+  <arg name="use_sim_time" default="true"/>
+  <arg name="rviz_en" default="true" />
+  <arg name="launch_prefix" default=""/> <!-- gdb -ex run //args -->
+  <arg name="world_file" default="$(find planner_gazebo_sim)/worlds/outdoor_city.world"/>
+  <arg name="rviz_config_file" default="$(find gbplanner)/config/rviz/rmf_obelix.rviz"/>
+  
+  <param name="use_sim_time" value="$(arg use_sim_time)"/>
+
+  <!-- Load robots configuration directly from YAML -->
+  <!-- This will load robots.yaml into /robots_config/robots parameter -->
+  <rosparam file="$(arg robots_config_file)" command="load" ns="robots_config"/>
+
+  <!-- Static TF: world -> navigation (shared across all robots) -->
+  <node pkg="tf" type="static_transform_publisher" name="tf_world_navigation" args="0 0 0 0 0 0 world navigation 100" />
+
+  <!-- ROS Gazebo (shared world) -->
+  <env name="GAZEBO_MODEL_PATH" value="${GAZEBO_MODEL_PATH}:$(find planner_gazebo_sim)/models:$(find subt_cave_sim)/models"/>
+  <include file="$(find gazebo_ros)/launch/empty_world.launch">
+    <arg name="world_name" value="$(arg world_file)" />
+    <arg name="gui" value="$(arg gazebo_gui_en)" />
+    <arg name="use_sim_time" value="$(arg use_sim_time)"/>
+    <arg name="paused" value="false" />
+    <arg name="verbose" value="false"/>
+  </include>
+
+  <!-- Spawn robots dynamically -->
+  <node pkg="gbplanner" type="spawn_robots.py" name="spawn_robots" output="screen" required="true">
+    <param name="launch_prefix" value="$(arg launch_prefix)"/>
+  </node>
+
+  <!-- RViz (single instance) - use original static config -->
+  <node pkg="rviz" type="rviz" name="gbplanner_ui" output="screen" args="-d $(arg rviz_config_file)" if="$(arg rviz_en)"/>
+
+</launch>
+

--- a/gbplanner/launch/smb/smb_sim.launch
+++ b/gbplanner/launch/smb/smb_sim.launch
@@ -1,7 +1,7 @@
 <launch>
   <!-- All settings -->
   <arg name="robot_name" default="smb"/>
-  <arg name="gazebo_gui_en" default="false"/>
+  <arg name="gazebo_gui_en" default="true"/>
   <arg name="use_sim_time" default="true"/>
   <arg name="rviz_en" default="true" />
   <arg name="launch_prefix" default=""/> <!-- gdb -ex run //args -->
@@ -14,7 +14,7 @@
   <arg name="map_config_file" default="$(arg voxblox_config_file)"/>
   <!-- <arg name="world_file" default="$(find planner_gazebo_sim)/worlds/niosh_osrf.world"/> -->
   <!-- <arg name="world_file" default="$(find planner_gazebo_sim)/worlds/darpa_cave_01.world"/> -->
-  <arg name="world_file" default="$(find planner_gazebo_sim)/worlds/pittsburgh_mine.world"/>
+  <arg name="world_file" default="$(find planner_gazebo_sim)/worlds/outdoor_city.world"/>
 
   <!-- Static TF -->
   <node pkg="tf" type="static_transform_publisher" name="tf_53" args="0 0 0 0 0 0 world navigation 100" />

--- a/gbplanner/package.xml
+++ b/gbplanner/package.xml
@@ -21,5 +21,7 @@
   <depend>planner_semantic_msgs</depend>
   <depend>adaptive_obb</depend>
   <depend>pcl_ros</depend>
+  <depend>rospy</depend>
+  <depend>roslaunch</depend>
   
 </package>

--- a/gbplanner/scripts/generate_multi_robot_rviz.py
+++ b/gbplanner/scripts/generate_multi_robot_rviz.py
@@ -1,0 +1,161 @@
+#!/usr/bin/env python3
+"""
+Generate multi-robot RViz config file.
+Reads robots.yaml and creates RViz config with displays for all robots.
+Can run standalone (no ROS required) or as ROS node.
+"""
+
+import yaml
+import os
+import sys
+import re
+
+def get_package_path():
+    """Get gbplanner package path - try ROS first, then relative path."""
+    try:
+        import rospkg
+        rospack = rospkg.RosPack()
+        return rospack.get_path('gbplanner')
+    except:
+        # Fallback: assume script is in gbplanner/scripts/
+        script_dir = os.path.dirname(os.path.abspath(__file__))
+        return os.path.dirname(os.path.dirname(script_dir))
+
+def generate_multi_robot_rviz_config():
+    """Generate RViz config for multi-robot setup."""
+    # Get package path
+    pkg_path = get_package_path()
+    
+    # Read robots config
+    robots_config_file = os.path.join(pkg_path, 'config', 'robots.yaml')
+    try:
+        with open(robots_config_file, 'r') as f:
+            config = yaml.safe_load(f)
+        robots = config.get('robots', [])
+    except Exception as e:
+        print(f"ERROR: Failed to read robots.yaml: {e}", file=sys.stderr)
+        robots = []
+    
+    if not robots:
+        print("WARN: No robots found in config, using default", file=sys.stderr)
+        robots = [{'name': 'rmf_obelix_1'}, {'name': 'rmf_obelix_2'}]
+    
+    # Read base RViz config
+    base_rviz_file = os.path.join(pkg_path, 'config', 'rviz', 'rmf_obelix.rviz')
+    try:
+        with open(base_rviz_file, 'r') as f:
+            rviz_config = f.read()
+    except Exception as e:
+        print(f"ERROR: Failed to read base RViz config: {e}", file=sys.stderr)
+        return
+    
+    # Ensure Fixed Frame is "world" (not "map" or anything else)
+    rviz_config = re.sub(r'Fixed Frame: [^\n]+', 'Fixed Frame: world', rviz_config)
+    
+    # Enable TF display
+    rviz_config = rviz_config.replace(
+        '        - Class: rviz/TF\n          Enabled: false',
+        '        - Class: rviz/TF\n          Enabled: true'
+    )
+    
+    # Update BaseLink axes to use world frame (or first robot)
+    if robots:
+        first_robot = robots[0]['name']
+        rviz_config = rviz_config.replace(
+            f'          Reference Frame: rmf_obelix/base_link',
+            f'          Reference Frame: {first_robot}/base_link'
+        )
+    
+    # Replace the single-robot pointcloud topic with multi-robot displays
+    # Find the VLP pointcloud display and replace it
+    old_vlp_pattern = '          Topic: /rmf_obelix/velodyne_points'
+    
+    # Build pointcloud displays for each robot
+    pointcloud_displays = []
+    for i, robot in enumerate(robots):
+        robot_name = robot['name']
+        # Create a pointcloud display for this robot
+        display = f'''          Topic: /{robot_name}/velodyne_points'''
+        pointcloud_displays.append((robot_name, display))
+    
+    # Replace the topic in the existing VLP display with first robot's topic
+    if pointcloud_displays:
+        first_robot_name, first_display = pointcloud_displays[0]
+        rviz_config = rviz_config.replace(old_vlp_pattern, first_display)
+        # Update display name
+        rviz_config = rviz_config.replace('          Name: VLP', f'          Name: {first_robot_name}_VLP')
+    
+    # Add additional pointcloud displays for other robots
+    # Find where to add them (after the Sensors group, before Voxblox group)
+    if len(pointcloud_displays) > 1:
+        # Find the Sensors group closing
+        sensors_end = rviz_config.find('      Enabled: false\n      Name: Sensors')
+        if sensors_end != -1:
+            # Find the end of Sensors group (before Voxblox)
+            voxblox_start = rviz_config.find('    - Class: rviz/Group\n      Displays:\n        - Class: voxblox_rviz_plugin/VoxbloxMesh', sensors_end)
+            if voxblox_start != -1:
+                # Insert new displays before Voxblox group
+                new_displays = []
+                for robot_name, _ in pointcloud_displays[1:]:  # Skip first, already added
+                    display_xml = f'''    - Alpha: 1
+      Autocompute Intensity Bounds: true
+      Autocompute Value Bounds:
+        Max Value: 10
+        Min Value: -10
+        Value: true
+      Axis: Z
+      Channel Name: intensity
+      Class: rviz/PointCloud2
+      Color: 255; 255; 255
+      Color Transformer: AxisColor
+      Decay Time: 0
+      Enabled: true
+      Invert Rainbow: false
+      Max Color: 255; 255; 255
+      Min Color: 0; 0; 0
+      Name: {robot_name}_VLP
+      Position Transformer: XYZ
+      Queue Size: 10
+      Selectable: true
+      Size (Pixels): 1
+      Size (m): 0.009999999776482582
+      Style: Points
+      Topic: /{robot_name}/velodyne_points
+      Unreliable: false
+      Use Fixed Frame: true
+      Use rainbow: true
+      Value: true'''
+                    new_displays.append(display_xml)
+                
+                if new_displays:
+                    before_voxblox = rviz_config[:voxblox_start]
+                    after_voxblox = rviz_config[voxblox_start:]
+                    rviz_config = before_voxblox + '\n'.join(new_displays) + '\n' + after_voxblox
+    
+    # Update odometry topic to first robot (or keep global if single robot)
+    if len(robots) == 1:
+        robot_name = robots[0]['name']
+        rviz_config = rviz_config.replace(
+            '      Topic: /ground_truth/odometry_throttled',
+            f'      Topic: /{robot_name}/ground_truth/odometry_throttled'
+        )
+    
+    # Write output config
+    output_file = os.path.join(pkg_path, 'config', 'rviz', 'rmf_obelix_multi.rviz')
+    try:
+        with open(output_file, 'w') as f:
+            f.write(rviz_config)
+        print(f"INFO: Generated multi-robot RViz config: {output_file}", file=sys.stderr)
+        print(f"INFO: Configured for {len(robots)} robots: {[r['name'] for r in robots]}", file=sys.stderr)
+    except Exception as e:
+        print(f"ERROR: Failed to write RViz config: {e}", file=sys.stderr)
+
+if __name__ == '__main__':
+    try:
+        generate_multi_robot_rviz_config()
+    except Exception as e:
+        print(f"FATAL: {e}", file=sys.stderr)
+        import traceback
+        traceback.print_exc(file=sys.stderr)
+        sys.exit(1)
+

--- a/gbplanner/scripts/spawn_model_direct.py
+++ b/gbplanner/scripts/spawn_model_direct.py
@@ -1,0 +1,460 @@
+#!/usr/bin/env python3
+"""
+Spawn Gazebo model directly with unique name.
+This bypasses spawn_mav.launch's model spawning to avoid name conflicts.
+Processes the xacro/urdf file and spawns via Gazebo service.
+"""
+
+# Print immediately to stderr so we can see if script is being called
+import sys
+print("=" * 60, file=sys.stderr)
+print("SPAWN_MODEL_DIRECT.PY: Script file loaded", file=sys.stderr)
+print("Python version: %s" % sys.version, file=sys.stderr)
+print("Arguments received: %s" % str(sys.argv), file=sys.stderr)
+print("=" * 60, file=sys.stderr)
+sys.stderr.flush()
+
+import rospy
+import os
+import subprocess
+import tempfile
+from gazebo_msgs.srv import SpawnModel
+from geometry_msgs.msg import Pose, Point, Quaternion
+
+def process_xacro_to_urdf(xacro_file, mav_name, namespace=None, enable_mavlink_interface=False, enable_logging=False, enable_ground_truth=True):
+    """Process xacro file to URDF using xacro command."""
+    try:
+        # Use xacro to process the file
+        # xacro needs mav_name, namespace, and other parameters
+        # If namespace not provided, use mav_name as namespace
+        if namespace is None:
+            namespace = mav_name
+        # Build xacro command with all required parameters
+        # These match what spawn_mav.launch typically passes
+        cmd = ['xacro', xacro_file,
+               'mav_name:=' + mav_name,
+               'namespace:=' + namespace,
+               'enable_mavlink_interface:=' + str(enable_mavlink_interface).lower(),
+               'enable_logging:=' + str(enable_logging).lower(),
+               'enable_ground_truth:=' + str(enable_ground_truth).lower()]
+        result = subprocess.run(cmd, capture_output=True, text=True, timeout=10)
+        if result.returncode != 0:
+            rospy.logerr("xacro processing failed: %s", result.stderr)
+            rospy.logerr("xacro stdout: %s", result.stdout)
+            return None
+        return result.stdout
+    except Exception as e:
+        rospy.logerr("Error processing xacro: %s", str(e))
+        return None
+
+def spawn_model_direct(base_name, robot_name, x, y, z):
+    """Spawn model directly via Gazebo service with unique name."""
+    # Always init node - anonymous=True allows multiple instances
+    rospy.init_node('spawn_model_direct_' + robot_name, anonymous=True)
+    
+    rospy.loginfo("=== Starting spawn_model_direct for robot: %s ===", robot_name)
+    rospy.loginfo("Parameters: base_name=%s, robot_name=%s, pos=(%s, %s, %s)", base_name, robot_name, x, y, z)
+    
+    # Wait a bit for Gazebo to fully initialize
+    rospy.sleep(2.0)
+    
+    # Wait for Gazebo services - try both URDF and SDF services
+    rospy.loginfo("Waiting for Gazebo spawn services...")
+    spawn_service_name = None
+    try:
+        rospy.wait_for_service('/gazebo/spawn_urdf_model', timeout=10.0)
+        spawn_service_name = '/gazebo/spawn_urdf_model'
+        rospy.loginfo("Found /gazebo/spawn_urdf_model service")
+    except rospy.ROSException:
+        rospy.logwarn("/gazebo/spawn_urdf_model not available, trying /gazebo/spawn_sdf_model")
+        try:
+            rospy.wait_for_service('/gazebo/spawn_sdf_model', timeout=10.0)
+            spawn_service_name = '/gazebo/spawn_sdf_model'
+            rospy.loginfo("Found /gazebo/spawn_sdf_model service")
+        except rospy.ROSException:
+            rospy.logerr("No Gazebo spawn services available!")
+            rospy.logerr("Please check that Gazebo is running and gazebo_ros plugins are loaded")
+            sys.exit(1)
+    
+    if not spawn_service_name:
+        rospy.logerr("Failed to find any spawn service!")
+        sys.exit(1)
+    
+    try:
+        spawn_model = rospy.ServiceProxy(spawn_service_name, SpawnModel)
+        
+        # Get model file path
+        try:
+            import rospkg
+            rospack = rospkg.RosPack()
+            rotors_desc_path = rospack.get_path('rotors_description')
+            model_file = os.path.join(rotors_desc_path, 'urdf', base_name + '.gazebo')
+        except Exception as e:
+            rospy.logerr("Could not find rotors_description package: %s", str(e))
+            return
+        
+        if not os.path.exists(model_file):
+            rospy.logerr("Model file not found: %s", model_file)
+            return
+        
+        # Process xacro to URDF
+        # Use base_name for mav_name and namespace (xacro file resolution)
+        # The URDF will be modified later to use robot_name for TF frames
+        # Pass enable_ground_truth=true to match single-robot setup
+        rospy.loginfo("Processing xacro file: %s with mav_name=%s, namespace=%s", model_file, base_name, base_name)
+        urdf_xml = process_xacro_to_urdf(model_file, base_name, namespace=base_name, 
+                                         enable_mavlink_interface=False, 
+                                         enable_logging=False, 
+                                         enable_ground_truth=True)
+        
+        if not urdf_xml:
+            rospy.logerr("Failed to process xacro file")
+            return
+        
+        # Replace frame names in URDF to use robot_name instead of base_name
+        # Use simple string replacement but be careful to preserve XML structure
+        # XML parsing loses comments and formatting, so we use targeted string replacement
+        import re
+        
+        # Store original length for validation
+        original_length = len(urdf_xml)
+        
+        # Debug: Check what we're replacing
+        rospy.loginfo("Replacing '%s' with '%s' in URDF", base_name, robot_name)
+        base_name_count = urdf_xml.count(base_name)
+        rospy.loginfo("Found '%s' %d times in URDF before replacement", base_name, base_name_count)
+        
+        # Replace in order of specificity to avoid double-replacement issues
+        # 1. Replace link names: <link name="base_name/...">
+        urdf_xml = urdf_xml.replace('<link name="' + base_name + '/', '<link name="' + robot_name + '/')
+        
+        # 2. Replace joint names: <joint name="base_name/...">
+        urdf_xml = urdf_xml.replace('<joint name="' + base_name + '/', '<joint name="' + robot_name + '/')
+        
+        # 3. Replace joint parent/child: <parent link="base_name/..."> or <child link="base_name/...">
+        urdf_xml = urdf_xml.replace('<parent link="' + base_name + '/', '<parent link="' + robot_name + '/')
+        urdf_xml = urdf_xml.replace('<child link="' + base_name + '/', '<child link="' + robot_name + '/')
+        
+        # 3b. Also replace non-namespaced joint names that might be created by macros (e.g., mount_joint)
+        # This must happen AFTER we replace the child link names, so we can check for robot_name/velodyne
+        # Pattern: <joint name="mount_joint"> with <child link="robot_name/velodyne">
+        if '<joint name="mount_joint"' in urdf_xml and robot_name + '/velodyne' in urdf_xml:
+            # Replace mount_joint with namespaced version
+            urdf_xml = urdf_xml.replace('<joint name="mount_joint"', '<joint name="' + robot_name + '/mount_joint"')
+            rospy.loginfo("Replaced non-namespaced mount_joint with namespaced version: %s/mount_joint", robot_name)
+        
+        # 4. Replace frame_id in plugins: frame_id="base_name/..."
+        urdf_xml = urdf_xml.replace('frame_id="' + base_name + '/', 'frame_id="' + robot_name + '/')
+        
+        # 5. Replace robot name attribute: <robot name="base_name">
+        urdf_xml = urdf_xml.replace('<robot name="' + base_name + '"', '<robot name="' + robot_name + '"')
+        
+        # 6. Replace in plugin frame references (common patterns in gazebo plugins)
+        urdf_xml = urdf_xml.replace('<frameName>' + base_name + '/', '<frameName>' + robot_name + '/')
+        urdf_xml = urdf_xml.replace('frame_name="' + base_name + '/', 'frame_name="' + robot_name + '/')
+        urdf_xml = urdf_xml.replace('reference_frame="' + base_name + '/', 'reference_frame="' + robot_name + '/')
+        # Also replace frameName that might have been expanded from ${name} variable
+        # Pattern: <frameName>rmf_obelix/velodyne</frameName> -> <frameName>rmf_obelix_1/velodyne</frameName>
+        urdf_xml = re.sub(r'(<frameName>)' + re.escape(base_name) + r'(/velodyne</frameName>)', 
+                         r'\1' + robot_name + r'\2', urdf_xml)
+        
+        # 7. Replace ${namespace} in plugin configurations (xacro variables that weren't expanded)
+        # This is critical for plugins to work correctly - they need the actual namespace, not the variable
+        urdf_xml = urdf_xml.replace('${namespace}', robot_name)
+        rospy.loginfo("Replaced ${namespace} variables with robot_name: %s", robot_name)
+        
+        # 8. DO NOT replace topic names - Gazebo's robot_namespace parameter handles this automatically
+        # When robot_namespace is set in spawn_model service, Gazebo automatically prefixes
+        # all plugin topics with the namespace. Using absolute topics breaks this mechanism.
+        # Keep relative topics like "velodyne_points" and let Gazebo namespace them to "/robot_name/velodyne_points"
+        
+        # Debug: Verify replacement worked
+        remaining_base_name = urdf_xml.count(base_name)
+        robot_name_count = urdf_xml.count(robot_name)
+        rospy.loginfo("After replacement: '%s' appears %d times, '%s' appears %d times", 
+                      base_name, remaining_base_name, robot_name, robot_name_count)
+        if remaining_base_name > 0:
+            # Find where base_name still appears
+            import re
+            remaining_matches = re.findall(r'[^"]*' + re.escape(base_name) + r'[^"]*', urdf_xml)
+            rospy.logwarn("WARNING: '%s' still appears %d times after replacement! Sample matches: %s", 
+                         base_name, remaining_base_name, remaining_matches[:5])
+        
+        # Validate that we didn't lose significant content (comments might be lost but structure should remain)
+        new_length = len(urdf_xml)
+        if new_length < original_length * 0.9:  # If we lost more than 10%, something's wrong
+            rospy.logwarn("WARNING: URDF length decreased significantly (was %d, now %d)", original_length, new_length)
+        
+        rospy.loginfo("URDF replacement via string replacement completed (length: %d -> %d)", original_length, new_length)
+        
+        # Check for velodyne link in URDF
+        if 'velodyne' in urdf_xml.lower():
+            velodyne_count = urdf_xml.lower().count('velodyne')
+            rospy.loginfo("URDF contains 'velodyne' %d times", velodyne_count)
+            # Try to find the velodyne link
+            velodyne_link_pattern = '<link name="' + robot_name + '/velodyne'
+            if velodyne_link_pattern in urdf_xml:
+                rospy.loginfo("Found velodyne link: %s", velodyne_link_pattern)
+                # Extract velodyne link section for debugging
+                import re
+                velodyne_link_match = re.search(r'<link name="' + robot_name + r'/velodyne[^>]*>.*?</link>', urdf_xml, re.DOTALL)
+                if velodyne_link_match:
+                    velodyne_link_xml = velodyne_link_match.group(0)
+                    rospy.loginfo("Velodyne link XML (first 500 chars): %s", velodyne_link_xml[:500])
+                # Check for velodyne joint - the OS0-128 macro creates a joint named "mount_joint"
+                # that connects parent (base_link) to child (velodyne link)
+                # The joint name might be namespaced or not, depending on the macro implementation
+                velodyne_joint_patterns = [
+                    '<joint name="' + robot_name + '/mount_joint',  # Namespaced mount_joint
+                    '<joint name="mount_joint"',  # Non-namespaced mount_joint (from macro)
+                    '<joint name="' + robot_name + '/velodyne',
+                    '<joint name="' + robot_name + '/velodyne_joint',
+                ]
+                joint_found = False
+                for pattern in velodyne_joint_patterns:
+                    if pattern in urdf_xml:
+                        rospy.loginfo("Found velodyne joint with pattern: %s", pattern)
+                        joint_found = True
+                        # Try to extract the joint XML - look for mount_joint that connects to velodyne
+                        joint_match = re.search(r'<joint[^>]*name="[^"]*mount_joint[^"]*"[^>]*>.*?</joint>', urdf_xml, re.DOTALL | re.IGNORECASE)
+                        if joint_match:
+                            velodyne_joint_xml = joint_match.group(0)
+                            rospy.loginfo("Velodyne mount_joint XML (first 500 chars): %s", velodyne_joint_xml[:500])
+                            # Check if it connects to velodyne link
+                            if robot_name + '/velodyne' in velodyne_joint_xml:
+                                rospy.loginfo("Confirmed: mount_joint connects to velodyne link")
+                            else:
+                                rospy.logwarn("WARNING: mount_joint found but doesn't connect to velodyne link!")
+                        break
+                
+                if not joint_found:
+                    rospy.logwarn("WARNING: Velodyne mount_joint not found! Searching for any joints connecting to velodyne...")
+                    # Search for any joint that has velodyne as child or parent
+                    all_velodyne_joints = re.findall(r'<joint[^>]*>.*?<child link="[^"]*velodyne[^"]*"', urdf_xml, re.DOTALL | re.IGNORECASE)
+                    if all_velodyne_joints:
+                        rospy.logwarn("Found joints connecting to velodyne: %s", [j[:200] for j in all_velodyne_joints[:3]])
+                    else:
+                        rospy.logerr("ERROR: No joint connecting to velodyne link found! This will prevent the link from being created in Gazebo!")
+                        rospy.logerr("The OS0-128 macro should create a 'mount_joint' connecting base_link to velodyne link")
+                # Check for velodyne plugin - look for libgazebo_ros_lidar plugin in gazebo block
+                # The plugin is in a <gazebo reference="...velodyne..."> tag
+                velodyne_gazebo_match = re.search(r'<gazebo[^>]*reference="[^"]*velodyne[^"]*"[^>]*>.*?</gazebo>', urdf_xml, re.DOTALL | re.IGNORECASE)
+                if velodyne_gazebo_match:
+                    velodyne_gazebo_xml = velodyne_gazebo_match.group(0)
+                    rospy.loginfo("Velodyne gazebo block found (first 800 chars): %s", velodyne_gazebo_xml[:800])
+                    # Check for lidar plugin
+                    if 'libgazebo_ros_lidar' in velodyne_gazebo_xml or 'gazebo_ros_laser_controller' in velodyne_gazebo_xml:
+                        rospy.loginfo("Found libgazebo_ros_lidar plugin in velodyne gazebo block")
+                        # Check if frameName is correct
+                        if robot_name + '/velodyne' in velodyne_gazebo_xml:
+                            rospy.loginfo("Plugin frameName is correctly namespaced: %s/velodyne", robot_name)
+                        else:
+                            rospy.logwarn("WARNING: Plugin frameName might not be correctly namespaced!")
+                            frame_match = re.search(r'<frameName>[^<]*</frameName>', velodyne_gazebo_xml, re.IGNORECASE)
+                            if frame_match:
+                                rospy.logwarn("Found frameName: %s (should be %s/velodyne)", frame_match.group(0), robot_name)
+                    else:
+                        rospy.logwarn("WARNING: libgazebo_ros_lidar plugin not found in velodyne gazebo block!")
+                else:
+                    rospy.logwarn("WARNING: Velodyne gazebo block not found! Searching for any plugin...")
+                    # Fallback: search for any plugin mentioning velodyne
+                    if '<plugin' in urdf_xml:
+                        plugin_match = re.search(r'<plugin[^>]*>.*?velodyne.*?</plugin>', urdf_xml, re.DOTALL | re.IGNORECASE)
+                        if plugin_match:
+                            plugin_xml = plugin_match.group(0)
+                            rospy.loginfo("Velodyne plugin found (first 500 chars): %s", plugin_xml[:500])
+                        else:
+                            rospy.logwarn("WARNING: No plugin found for velodyne!")
+            else:
+                rospy.logwarn("WARNING: Velodyne link pattern '%s' not found in URDF!", velodyne_link_pattern)
+                # Check for any velodyne link
+                velodyne_links = re.findall(r'<link name="[^"]*velodyne[^"]*"', urdf_xml)
+                if velodyne_links:
+                    rospy.logwarn("Found velodyne links with different names: %s", velodyne_links)
+                else:
+                    rospy.logerr("ERROR: No velodyne link found in URDF at all!")
+        else:
+            rospy.logerr("ERROR: URDF does not contain 'velodyne' - sensor may not be included!")
+        
+        # Validate URDF XML structure using Python's xml parser
+        try:
+            import xml.etree.ElementTree as ET
+            # Try to parse the URDF to ensure it's valid XML
+            ET.fromstring(urdf_xml)
+            rospy.loginfo("URDF XML validation passed")
+        except ET.ParseError as e:
+            rospy.logerr("URDF XML validation FAILED: %s", str(e))
+            rospy.logerr("This URDF will likely fail in Gazebo!")
+            # Write to temp file for debugging
+            try:
+                with tempfile.NamedTemporaryFile(mode='w', suffix='.urdf', delete=False) as f:
+                    f.write(urdf_xml)
+                    rospy.logerr("Invalid URDF written to: %s", f.name)
+            except:
+                pass
+        
+        # Basic XML validation - check for balanced tags
+        open_tags = urdf_xml.count('<')
+        close_tags = urdf_xml.count('>')
+        if open_tags != close_tags:
+            rospy.logwarn("WARNING: XML tag count mismatch (open: %d, close: %d)", open_tags, close_tags)
+        
+        # Debug: log a snippet of the URDF to verify replacement
+        rospy.loginfo("URDF replacement complete for robot %s (replaced %s -> %s)", robot_name, base_name, robot_name)
+        rospy.loginfo("URDF sample (first 500 chars): %s", urdf_xml[:500])
+        
+        # Check if visual/collision elements are present
+        visual_count = urdf_xml.count('<visual')
+        collision_count = urdf_xml.count('<collision')
+        link_count = urdf_xml.count('<link name=')
+        rospy.loginfo("URDF contains %d links, %d visual elements, %d collision elements", link_count, visual_count, collision_count)
+        
+        # Check for base_link specifically
+        if robot_name + '/base_link' in urdf_xml:
+            base_link_start = urdf_xml.find('<link name="' + robot_name + '/base_link')
+            if base_link_start != -1:
+                base_link_end = urdf_xml.find('</link>', base_link_start)
+                if base_link_end != -1:
+                    base_link_xml = urdf_xml[base_link_start:base_link_end+7]
+                    has_visual = '<visual' in base_link_xml
+                    has_collision = '<collision' in base_link_xml
+                    rospy.loginfo("base_link found: has_visual=%s, has_collision=%s", has_visual, has_collision)
+                    if not has_visual and not has_collision:
+                        rospy.logwarn("WARNING: base_link has no visual or collision elements! This might cause rendering issues.")
+                        rospy.logwarn("base_link XML snippet: %s", base_link_xml[:300])
+        
+        # Create pose
+        pose = Pose()
+        pose.position = Point(float(x), float(y), float(z))
+        pose.orientation = Quaternion(0, 0, 0, 1)  # Identity quaternion
+        
+        # Spawn with unique name
+        rospy.loginfo("Spawning model %s at (%s, %s, %s) using service %s", robot_name, x, y, z, spawn_service_name)
+        rospy.loginfo("URDF XML length: %d characters", len(urdf_xml))
+        
+        # Add a small delay to avoid race conditions when spawning multiple models
+        # This gives Gazebo time to finish processing the previous model
+        rospy.sleep(0.5)
+        
+        try:
+            # Spawn with robot_namespace - Gazebo will automatically namespace plugin topics
+            # The URDF links are pre-namespaced for TF frames, but plugin topics should be relative
+            # Gazebo's robot_namespace will prefix plugin topics with the namespace
+            rospy.loginfo("Spawning model with robot_namespace=%s", robot_name)
+            spawn_resp = spawn_model(
+                model_name=robot_name,
+                model_xml=urdf_xml,
+                robot_namespace=robot_name,  # This namespaces plugin topics automatically
+                initial_pose=pose,
+                reference_frame='world'
+            )
+        except rospy.ServiceException as e:
+            rospy.logerr("Service call exception: %s", str(e))
+            rospy.logerr("This might indicate the service doesn't accept URDF, trying to convert to SDF...")
+            # Try converting URDF to SDF if needed
+            # Note: SpawnModel is already imported at top of file
+            # For SDF, we might need to wrap URDF differently
+            # But for now, just log the error
+            rospy.logerr("Cannot automatically convert URDF to SDF. Please check service type.")
+            return
+        
+        if spawn_resp.success:
+            rospy.loginfo("=== Successfully spawned model %s ===", robot_name)
+            
+            # Gazebo should publish world->model_name/base_link automatically,
+            # but when using robot_namespace it might not work correctly.
+            # Add a static transform publisher as backup to ensure TF tree is connected
+            import subprocess
+            # static_transform_publisher format: x y z yaw pitch roll frame_id child_frame_id period_in_ms
+            tf_cmd = [
+                'rosrun', 'tf', 'static_transform_publisher',
+                str(x), str(y), str(z),  # translation (x y z)
+                '0', '0', '0',  # rotation (yaw pitch roll in radians)
+                'world', robot_name + '/base_link', '100'
+            ]
+            rospy.loginfo("Publishing static transform: world -> %s/base_link at (%s, %s, %s)", robot_name, x, y, z)
+            # Run in background - this will keep running
+            subprocess.Popen(tf_cmd, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+            rospy.loginfo("Static transform publisher started for world -> %s/base_link", robot_name)
+            
+            # Verify model exists in Gazebo
+            rospy.sleep(0.5)  # Give Gazebo time to register the model
+            try:
+                from gazebo_msgs.srv import GetModelState
+                get_state = rospy.ServiceProxy('/gazebo/get_model_state', GetModelState)
+                state_resp = get_state(model_name=robot_name, relative_entity_name='')
+                if state_resp.success:
+                    rospy.loginfo("Verified: Model %s exists in Gazebo at position (%f, %f, %f)", 
+                                 robot_name, state_resp.pose.position.x, 
+                                 state_resp.pose.position.y, state_resp.pose.position.z)
+                else:
+                    rospy.logwarn("Model %s spawn reported success but not found in Gazebo!", robot_name)
+            except Exception as e:
+                rospy.logwarn("Could not verify model existence: %s", str(e))
+            
+            # Keep node alive to prevent launch file from thinking everything is done
+            rospy.loginfo("Spawn complete. Keeping node alive (other nodes will keep launch file running).")
+            rospy.spin()  # Keep node alive indefinitely
+            return
+        else:
+            rospy.logerr("=== Failed to spawn model %s ===", robot_name)
+            rospy.logerr("Status message: %s", spawn_resp.status_message)
+            rospy.logerr("Possible causes:")
+            rospy.logerr("  1. Model name already exists in Gazebo")
+            rospy.logerr("  2. URDF is malformed")
+            rospy.logerr("  3. Invalid spawn position")
+            rospy.logerr("  4. Gazebo plugin error")
+            rospy.logerr("Check Gazebo console for more details")
+            # Keep node alive even on failure - let respawn handle retries
+            # This prevents launch file from exiting
+            rospy.logwarn("Spawn failed but keeping node alive for respawn...")
+            rospy.spin()  # Keep node alive so respawn can retry
+            return
+            
+    except rospy.ServiceException as e:
+        rospy.logerr("Service call failed: %s", str(e))
+        rospy.logwarn("Keeping node alive for respawn...")
+        rospy.spin()  # Keep node alive so respawn can retry
+        return
+    except Exception as e:
+        rospy.logerr("Error spawning model: %s", str(e))
+        import traceback
+        traceback.print_exc()
+        rospy.logwarn("Keeping node alive for respawn...")
+        rospy.spin()  # Keep node alive so respawn can retry
+        return
+
+if __name__ == '__main__':
+    # Print to stderr so it shows up even if stdout is buffered
+    print("=" * 60, file=sys.stderr)
+    print("SPAWN_MODEL_DIRECT.PY STARTING", file=sys.stderr)
+    print("Arguments: %s" % str(sys.argv), file=sys.stderr)
+    print("=" * 60, file=sys.stderr)
+    sys.stderr.flush()
+    
+    if len(sys.argv) < 6:
+        print("Usage: spawn_model_direct.py <base_name> <robot_name> <x> <y> <z>", file=sys.stderr)
+        print("Got %d arguments: %s" % (len(sys.argv), str(sys.argv)), file=sys.stderr)
+        sys.exit(1)
+    
+    base_name = sys.argv[1]
+    robot_name = sys.argv[2]
+    x = sys.argv[3]
+    y = sys.argv[4]
+    z = sys.argv[5]
+    
+    print("Parsed arguments: base_name=%s, robot_name=%s, pos=(%s, %s, %s)" % 
+          (base_name, robot_name, x, y, z), file=sys.stderr)
+    sys.stderr.flush()
+    
+    try:
+        spawn_model_direct(base_name, robot_name, x, y, z)
+    except rospy.ROSInterruptException:
+        pass
+    except Exception as e:
+        print("FATAL ERROR in spawn_model_direct: %s" % str(e), file=sys.stderr)
+        import traceback
+        traceback.print_exc(file=sys.stderr)
+        sys.stderr.flush()
+        raise
+

--- a/gbplanner/scripts/spawn_model_direct.py
+++ b/gbplanner/scripts/spawn_model_direct.py
@@ -26,14 +26,16 @@ def process_xacro_to_urdf(xacro_file, mav_name, namespace=None, enable_mavlink_i
     try:
         # Use xacro to process the file
         # xacro needs mav_name, namespace, and other parameters
-        # If namespace not provided, use mav_name as namespace
+        # IMPORTANT: namespace should be the actual robot namespace (robot_name), not base_name
+        # This ensures plugin robotNamespace is set correctly by xacro
         if namespace is None:
             namespace = mav_name
         # Build xacro command with all required parameters
         # These match what spawn_mav.launch typically passes
+        # Note: namespace is passed to xacro, which expands ${namespace} in plugin XML
         cmd = ['xacro', xacro_file,
                'mav_name:=' + mav_name,
-               'namespace:=' + namespace,
+               'namespace:=' + namespace,  # This will be expanded in plugin robotNamespace
                'enable_mavlink_interface:=' + str(enable_mavlink_interface).lower(),
                'enable_logging:=' + str(enable_logging).lower(),
                'enable_ground_truth:=' + str(enable_ground_truth).lower()]
@@ -98,11 +100,11 @@ def spawn_model_direct(base_name, robot_name, x, y, z):
             return
         
         # Process xacro to URDF
-        # Use base_name for mav_name and namespace (xacro file resolution)
-        # The URDF will be modified later to use robot_name for TF frames
-        # Pass enable_ground_truth=true to match single-robot setup
-        rospy.loginfo("Processing xacro file: %s with mav_name=%s, namespace=%s", model_file, base_name, base_name)
-        urdf_xml = process_xacro_to_urdf(model_file, base_name, namespace=base_name, 
+        # IMPORTANT: Pass robot_name as namespace to xacro so plugin robotNamespace is set correctly
+        # xacro will expand ${namespace} in plugin XML to robot_name
+        # Use base_name for mav_name (for file resolution), but robot_name for namespace
+        rospy.loginfo("Processing xacro file: %s with mav_name=%s, namespace=%s", model_file, base_name, robot_name)
+        urdf_xml = process_xacro_to_urdf(model_file, base_name, namespace=robot_name, 
                                          enable_mavlink_interface=False, 
                                          enable_logging=False, 
                                          enable_ground_truth=True)
@@ -150,32 +152,130 @@ def spawn_model_direct(base_name, robot_name, x, y, z):
             rospy.loginfo("Replaced non-namespaced mount_joint with namespaced version: %s/mount_joint", robot_name)
         
         # 4. Replace frame_id in plugins: frame_id="base_name/..."
+        # This applies to ALL plugins (cameras, IMU, lidar, etc.)
         urdf_xml = urdf_xml.replace('frame_id="' + base_name + '/', 'frame_id="' + robot_name + '/')
         
         # 5. Replace robot name attribute: <robot name="base_name">
         urdf_xml = urdf_xml.replace('<robot name="' + base_name + '"', '<robot name="' + robot_name + '"')
         
         # 6. Replace in plugin frame references (common patterns in gazebo plugins)
-        # IMPORTANT: When using robot_namespace in spawn service, Gazebo automatically prefixes frame names
-        # So we need to use RELATIVE frame names (just "velodyne") not absolute ("robot_name/velodyne")
-        # Pattern: <frameName>rmf_obelix/velodyne</frameName> -> <frameName>velodyne</frameName>
-        # Gazebo's robot_namespace will then make it "robot_name/velodyne"
+        # IMPORTANT: When xacro expands ${namespace}, it might set frameName to "${namespace}/velodyne"
+        # We need to ensure frameName is relative (just "velodyne") not absolute ("robot_name/velodyne")
+        # This applies to ALL plugins that use frameName, frame_name, or reference_frame
+        # Pattern: <frameName>rmf_obelix/velodyne</frameName> or <frameName>rmf_obelix_1/velodyne</frameName> -> <frameName>velodyne</frameName>
+        # Also handle ${namespace}/velodyne patterns
         urdf_xml = re.sub(r'(<frameName>)' + re.escape(base_name) + r'(/velodyne</frameName>)', 
                          r'\1velodyne</frameName>', urdf_xml)
-        # Also handle other frameName patterns that might have base_name prefix
+        urdf_xml = re.sub(r'(<frameName>)' + re.escape(robot_name) + r'(/velodyne</frameName>)', 
+                         r'\1velodyne</frameName>', urdf_xml)
+        # Also handle other frameName patterns that might have base_name or robot_name prefix (cameras, IMU, etc.)
         urdf_xml = urdf_xml.replace('<frameName>' + base_name + '/', '<frameName>')
+        urdf_xml = urdf_xml.replace('<frameName>' + robot_name + '/', '<frameName>')
         urdf_xml = urdf_xml.replace('frame_name="' + base_name + '/', 'frame_name="')
+        urdf_xml = urdf_xml.replace('frame_name="' + robot_name + '/', 'frame_name="')
         urdf_xml = urdf_xml.replace('reference_frame="' + base_name + '/', 'reference_frame="')
+        urdf_xml = urdf_xml.replace('reference_frame="' + robot_name + '/', 'reference_frame="')
+        # Also handle cameraFrameName (used by camera plugins)
+        urdf_xml = urdf_xml.replace('<cameraFrameName>' + base_name + '/', '<cameraFrameName>')
+        urdf_xml = urdf_xml.replace('cameraFrameName="' + base_name + '/', 'cameraFrameName="')
+        # Handle opticalFrameName (used by camera plugins)
+        urdf_xml = urdf_xml.replace('<opticalFrameName>' + base_name + '/', '<opticalFrameName>')
+        urdf_xml = urdf_xml.replace('opticalFrameName="' + base_name + '/', 'opticalFrameName="')
         
         # 7. Replace ${namespace} in plugin configurations (xacro variables that weren't expanded)
         # This is critical for plugins to work correctly - they need the actual namespace, not the variable
-        urdf_xml = urdf_xml.replace('${namespace}', robot_name)
-        rospy.loginfo("Replaced ${namespace} variables with robot_name: %s", robot_name)
+        # IMPORTANT: For ground truth plugin, ${namespace} should be replaced with robot_name
+        # But when using robot_namespace in spawn service, Gazebo will auto-namespace plugin topics
+        # So we need to check if the plugin uses ${namespace} for robotNamespace parameter
+        namespace_replacements = urdf_xml.count('${namespace}')
+        if namespace_replacements > 0:
+            rospy.loginfo("Found %d ${namespace} variables, replacing with robot_name: %s", namespace_replacements, robot_name)
+            urdf_xml = urdf_xml.replace('${namespace}', robot_name)
+            rospy.loginfo("Replaced ${namespace} variables with robot_name: %s", robot_name)
+        else:
+            rospy.loginfo("No ${namespace} variables found in URDF (this is OK if xacro expanded them)")
         
         # 8. DO NOT replace topic names - Gazebo's robot_namespace parameter handles this automatically
         # When robot_namespace is set in spawn_model service, Gazebo automatically prefixes
         # all plugin topics with the namespace. Using absolute topics breaks this mechanism.
         # Keep relative topics like "velodyne_points" and let Gazebo namespace them to "/robot_name/velodyne_points"
+        
+        # Debug: Check for all plugins that might need namespace fixes
+        import re
+        # Find all plugins in URDF
+        all_plugins = re.findall(r'<plugin[^>]*>.*?</plugin>', urdf_xml, re.DOTALL | re.IGNORECASE)
+        rospy.loginfo("Found %d plugin(s) in URDF", len(all_plugins))
+        
+        # Check for specific plugins that need special handling
+        plugin_types = {
+            'librotors_gazebo_ros_interface_plugin': 'Ground truth odometry',
+            'libgazebo_ros_lidar': 'Lidar (velodyne)',
+            'libgazebo_ros_camera': 'Camera',
+            'libgazebo_ros_imu': 'IMU',
+            'libgazebo_ros_openni_kinect': 'Kinect camera',
+            'libgazebo_ros_depth_camera': 'Depth camera',
+            'libgazebo_ros_multicamera': 'Multi-camera',
+            'libgazebo_ros_imu_sensor': 'IMU sensor',
+            'libgazebo_ros_p3d': 'Odometry (p3d)',
+        }
+        
+        for plugin_lib, plugin_name in plugin_types.items():
+            if plugin_lib in urdf_xml:
+                rospy.loginfo("Found %s plugin: %s", plugin_name, plugin_lib)
+                # Extract plugin XML for this type
+                plugin_matches = re.findall(r'<plugin[^>]*filename="[^"]*' + re.escape(plugin_lib) + r'[^"]*"[^>]*>.*?</plugin>', 
+                                           urdf_xml, re.DOTALL | re.IGNORECASE)
+                for i, plugin_xml in enumerate(plugin_matches):
+                    # Check for common issues
+                    if base_name + '/' in plugin_xml:
+                        rospy.logwarn("WARNING: %s plugin #%d still contains base_name '%s' - may need additional fixes!", 
+                                     plugin_name, i+1, base_name)
+                    if '${namespace}' in plugin_xml:
+                        rospy.logwarn("WARNING: %s plugin #%d still contains ${namespace} - should have been replaced!", 
+                                     plugin_name, i+1)
+                    # Check for frameName with base_name (should be relative)
+                    if '<frameName>' + base_name + '/' in plugin_xml:
+                        rospy.logwarn("WARNING: %s plugin #%d has absolute frameName with base_name - should be relative!", 
+                                     plugin_name, i+1)
+        
+        # Specifically check and fix ground truth plugin
+        # IMPORTANT: The rotors_gazebo_ros_interface_plugin needs robotNamespace to be set correctly.
+        # When using robot_namespace in spawn service, we should set robotNamespace to match robot_name
+        # so the plugin publishes to the correct namespaced topics.
+        if 'librotors_gazebo_ros_interface_plugin' in urdf_xml:
+            rospy.loginfo("Found librotors_gazebo_ros_interface_plugin in URDF")
+            plugin_match = re.search(r'<plugin[^>]*name="ros_interface_plugin"[^>]*>.*?</plugin>', urdf_xml, re.DOTALL | re.IGNORECASE)
+            if plugin_match:
+                plugin_xml = plugin_match.group(0)
+                rospy.loginfo("Ground truth plugin XML (before fix): %s", plugin_xml[:800])
+                
+                # Ensure robotNamespace is set to robot_name (not base_name)
+                # The plugin will publish to topics like /robot_name/ground_truth/odometry
+                if '<robotNamespace>' in plugin_xml:
+                    # Replace existing robotNamespace value with robot_name
+                    plugin_xml_fixed = re.sub(
+                        r'<robotNamespace>.*?</robotNamespace>',
+                        '<robotNamespace>' + robot_name + '</robotNamespace>',
+                        plugin_xml,
+                        flags=re.DOTALL | re.IGNORECASE
+                    )
+                    if plugin_xml_fixed != plugin_xml:
+                        urdf_xml = urdf_xml.replace(plugin_xml, plugin_xml_fixed)
+                        rospy.loginfo("Updated robotNamespace to %s in ground truth plugin", robot_name)
+                        rospy.loginfo("Ground truth plugin XML (after fix): %s", plugin_xml_fixed[:800])
+                    else:
+                        rospy.logwarn("WARNING: Failed to update robotNamespace in plugin XML!")
+                else:
+                    # Add robotNamespace if it doesn't exist
+                    if '</plugin>' in plugin_xml:
+                        plugin_xml_fixed = plugin_xml.replace(
+                            '</plugin>',
+                            '<robotNamespace>' + robot_name + '</robotNamespace></plugin>'
+                        )
+                        urdf_xml = urdf_xml.replace(plugin_xml, plugin_xml_fixed)
+                        rospy.loginfo("Added robotNamespace=%s to ground truth plugin", robot_name)
+        else:
+            rospy.logwarn("WARNING: librotors_gazebo_ros_interface_plugin NOT found in URDF! Ground truth odometry will not be published!")
         
         # Debug: Verify replacement worked
         remaining_base_name = urdf_xml.count(base_name)
@@ -254,16 +354,32 @@ def spawn_model_direct(base_name, robot_name, x, y, z):
                     # Check for lidar plugin
                     if 'libgazebo_ros_lidar' in velodyne_gazebo_xml or 'gazebo_ros_laser_controller' in velodyne_gazebo_xml:
                         rospy.loginfo("Found libgazebo_ros_lidar plugin in velodyne gazebo block")
-                        # Check if frameName is correct (should be relative "velodyne", not absolute)
-                        # Gazebo's robot_namespace will automatically prefix it to "robot_name/velodyne"
+                        # Fix frameName if it's absolute - should be relative "velodyne"
+                        # When xacro expands ${namespace}, it might set frameName to "${namespace}/velodyne" = "robot_name/velodyne"
+                        # We need to make it relative so it resolves correctly
+                        if robot_name + '/velodyne' in velodyne_gazebo_xml:
+                            velodyne_gazebo_xml_fixed = velodyne_gazebo_xml.replace(
+                                '<frameName>' + robot_name + '/velodyne</frameName>',
+                                '<frameName>velodyne</frameName>'
+                            )
+                            if velodyne_gazebo_xml_fixed != velodyne_gazebo_xml:
+                                urdf_xml = urdf_xml.replace(velodyne_gazebo_xml, velodyne_gazebo_xml_fixed)
+                                rospy.loginfo("Fixed velodyne plugin frameName: changed from %s/velodyne to velodyne (relative)", robot_name)
+                        # Also check for base_name/velodyne
+                        if base_name + '/velodyne' in velodyne_gazebo_xml:
+                            velodyne_gazebo_xml_fixed = velodyne_gazebo_xml.replace(
+                                '<frameName>' + base_name + '/velodyne</frameName>',
+                                '<frameName>velodyne</frameName>'
+                            )
+                            if velodyne_gazebo_xml_fixed != velodyne_gazebo_xml:
+                                urdf_xml = urdf_xml.replace(velodyne_gazebo_xml, velodyne_gazebo_xml_fixed)
+                                rospy.loginfo("Fixed velodyne plugin frameName: changed from %s/velodyne to velodyne (relative)", base_name)
+                        # Check if frameName is now correct
                         frame_match = re.search(r'<frameName>[^<]*</frameName>', velodyne_gazebo_xml, re.IGNORECASE)
                         if frame_match:
                             frame_name = frame_match.group(0)
                             if frame_name == '<frameName>velodyne</frameName>':
-                                rospy.loginfo("Plugin frameName is correct (relative): velodyne (will be namespaced to %s/velodyne by Gazebo)", robot_name)
-                            elif robot_name + '/velodyne' in frame_name:
-                                rospy.logwarn("WARNING: Plugin frameName is absolute (%s) but should be relative (velodyne)!", frame_name)
-                                rospy.logwarn("Gazebo's robot_namespace will double-prefix this, causing frame errors!")
+                                rospy.loginfo("Plugin frameName is correct (relative): velodyne")
                             else:
                                 rospy.logwarn("Found frameName: %s (should be 'velodyne' for relative naming)", frame_name)
                     else:
@@ -350,14 +466,14 @@ def spawn_model_direct(base_name, robot_name, x, y, z):
         rospy.sleep(0.5)
         
         try:
-            # Spawn with robot_namespace - Gazebo will automatically namespace plugin topics
-            # The URDF links are pre-namespaced for TF frames, but plugin topics should be relative
-            # Gazebo's robot_namespace will prefix plugin topics with the namespace
-            rospy.loginfo("Spawning model with robot_namespace=%s", robot_name)
+            # Spawn model - use robot_namespace for plugins that don't have robotNamespace (like velodyne)
+            # Ground truth plugin has robotNamespace set, so it will use that (takes precedence)
+            # Velodyne plugin doesn't have robotNamespace, so it needs robot_namespace in spawn
+            rospy.loginfo("Spawning model %s with robot_namespace=%s", robot_name, robot_name)
             spawn_resp = spawn_model(
                 model_name=robot_name,
                 model_xml=urdf_xml,
-                robot_namespace=robot_name,  # This namespaces plugin topics automatically
+                robot_namespace=robot_name,  # This namespaces plugins without robotNamespace (like velodyne)
                 initial_pose=pose,
                 reference_frame='world'
             )
@@ -374,21 +490,9 @@ def spawn_model_direct(base_name, robot_name, x, y, z):
         if spawn_resp.success:
             rospy.loginfo("=== Successfully spawned model %s ===", robot_name)
             
-            # Gazebo should publish world->model_name/base_link automatically,
-            # but when using robot_namespace it might not work correctly.
-            # Add a static transform publisher as backup to ensure TF tree is connected
-            import subprocess
-            # static_transform_publisher format: x y z yaw pitch roll frame_id child_frame_id period_in_ms
-            tf_cmd = [
-                'rosrun', 'tf', 'static_transform_publisher',
-                str(x), str(y), str(z),  # translation (x y z)
-                '0', '0', '0',  # rotation (yaw pitch roll in radians)
-                'world', robot_name + '/base_link', '100'
-            ]
-            rospy.loginfo("Publishing static transform: world -> %s/base_link at (%s, %s, %s)", robot_name, x, y, z)
-            # Run in background - this will keep running
-            subprocess.Popen(tf_cmd, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
-            rospy.loginfo("Static transform publisher started for world -> %s/base_link", robot_name)
+            # Gazebo automatically publishes world->model_name/base_link when model is spawned
+            # Do NOT add a static transform publisher as it causes TF_REPEATED_DATA warnings
+            # The transform is published by Gazebo's physics engine automatically
             
             # Verify model exists in Gazebo
             rospy.sleep(0.5)  # Give Gazebo time to register the model

--- a/gbplanner/scripts/spawn_model_direct.py
+++ b/gbplanner/scripts/spawn_model_direct.py
@@ -135,6 +135,12 @@ def spawn_model_direct(base_name, robot_name, x, y, z):
         urdf_xml = urdf_xml.replace('<parent link="' + base_name + '/', '<parent link="' + robot_name + '/')
         urdf_xml = urdf_xml.replace('<child link="' + base_name + '/', '<child link="' + robot_name + '/')
         
+        # 3a. Replace gazebo reference attributes (CRITICAL for velodyne plugin!)
+        # Pattern: <gazebo reference="rmf_obelix/velodyne"> -> <gazebo reference="rmf_obelix_1/velodyne">
+        urdf_xml = urdf_xml.replace('reference="' + base_name + '/', 'reference="' + robot_name + '/')
+        urdf_xml = urdf_xml.replace('reference="' + base_name + '"', 'reference="' + robot_name + '"')
+        rospy.loginfo("Replaced gazebo reference attributes from %s to %s", base_name, robot_name)
+        
         # 3b. Also replace non-namespaced joint names that might be created by macros (e.g., mount_joint)
         # This must happen AFTER we replace the child link names, so we can check for robot_name/velodyne
         # Pattern: <joint name="mount_joint"> with <child link="robot_name/velodyne">
@@ -150,13 +156,16 @@ def spawn_model_direct(base_name, robot_name, x, y, z):
         urdf_xml = urdf_xml.replace('<robot name="' + base_name + '"', '<robot name="' + robot_name + '"')
         
         # 6. Replace in plugin frame references (common patterns in gazebo plugins)
-        urdf_xml = urdf_xml.replace('<frameName>' + base_name + '/', '<frameName>' + robot_name + '/')
-        urdf_xml = urdf_xml.replace('frame_name="' + base_name + '/', 'frame_name="' + robot_name + '/')
-        urdf_xml = urdf_xml.replace('reference_frame="' + base_name + '/', 'reference_frame="' + robot_name + '/')
-        # Also replace frameName that might have been expanded from ${name} variable
-        # Pattern: <frameName>rmf_obelix/velodyne</frameName> -> <frameName>rmf_obelix_1/velodyne</frameName>
+        # IMPORTANT: When using robot_namespace in spawn service, Gazebo automatically prefixes frame names
+        # So we need to use RELATIVE frame names (just "velodyne") not absolute ("robot_name/velodyne")
+        # Pattern: <frameName>rmf_obelix/velodyne</frameName> -> <frameName>velodyne</frameName>
+        # Gazebo's robot_namespace will then make it "robot_name/velodyne"
         urdf_xml = re.sub(r'(<frameName>)' + re.escape(base_name) + r'(/velodyne</frameName>)', 
-                         r'\1' + robot_name + r'\2', urdf_xml)
+                         r'\1velodyne</frameName>', urdf_xml)
+        # Also handle other frameName patterns that might have base_name prefix
+        urdf_xml = urdf_xml.replace('<frameName>' + base_name + '/', '<frameName>')
+        urdf_xml = urdf_xml.replace('frame_name="' + base_name + '/', 'frame_name="')
+        urdf_xml = urdf_xml.replace('reference_frame="' + base_name + '/', 'reference_frame="')
         
         # 7. Replace ${namespace} in plugin configurations (xacro variables that weren't expanded)
         # This is critical for plugins to work correctly - they need the actual namespace, not the variable
@@ -245,14 +254,18 @@ def spawn_model_direct(base_name, robot_name, x, y, z):
                     # Check for lidar plugin
                     if 'libgazebo_ros_lidar' in velodyne_gazebo_xml or 'gazebo_ros_laser_controller' in velodyne_gazebo_xml:
                         rospy.loginfo("Found libgazebo_ros_lidar plugin in velodyne gazebo block")
-                        # Check if frameName is correct
-                        if robot_name + '/velodyne' in velodyne_gazebo_xml:
-                            rospy.loginfo("Plugin frameName is correctly namespaced: %s/velodyne", robot_name)
-                        else:
-                            rospy.logwarn("WARNING: Plugin frameName might not be correctly namespaced!")
-                            frame_match = re.search(r'<frameName>[^<]*</frameName>', velodyne_gazebo_xml, re.IGNORECASE)
-                            if frame_match:
-                                rospy.logwarn("Found frameName: %s (should be %s/velodyne)", frame_match.group(0), robot_name)
+                        # Check if frameName is correct (should be relative "velodyne", not absolute)
+                        # Gazebo's robot_namespace will automatically prefix it to "robot_name/velodyne"
+                        frame_match = re.search(r'<frameName>[^<]*</frameName>', velodyne_gazebo_xml, re.IGNORECASE)
+                        if frame_match:
+                            frame_name = frame_match.group(0)
+                            if frame_name == '<frameName>velodyne</frameName>':
+                                rospy.loginfo("Plugin frameName is correct (relative): velodyne (will be namespaced to %s/velodyne by Gazebo)", robot_name)
+                            elif robot_name + '/velodyne' in frame_name:
+                                rospy.logwarn("WARNING: Plugin frameName is absolute (%s) but should be relative (velodyne)!", frame_name)
+                                rospy.logwarn("Gazebo's robot_namespace will double-prefix this, causing frame errors!")
+                            else:
+                                rospy.logwarn("Found frameName: %s (should be 'velodyne' for relative naming)", frame_name)
                     else:
                         rospy.logwarn("WARNING: libgazebo_ros_lidar plugin not found in velodyne gazebo block!")
                 else:

--- a/gbplanner/scripts/spawn_model_direct_wrapper.py
+++ b/gbplanner/scripts/spawn_model_direct_wrapper.py
@@ -1,0 +1,32 @@
+#!/usr/bin/env python3
+"""
+Wrapper script for spawn_model_direct.py
+This wrapper is installed and calls the actual script from source directory.
+This works around the install issue with catkin_simple.
+"""
+import sys
+import os
+
+# Get the package path
+try:
+    import rospkg
+    rospack = rospkg.RosPack()
+    pkg_path = rospack.get_path('gbplanner')
+    script_path = os.path.join(pkg_path, 'scripts', 'spawn_model_direct.py')
+    
+    # Check if script exists
+    if not os.path.exists(script_path):
+        print("ERROR: spawn_model_direct.py not found at: %s" % script_path, file=sys.stderr)
+        sys.exit(1)
+    
+    # Execute the actual script with all arguments
+    # Replace this process with the actual script
+    os.execv(script_path, [script_path] + sys.argv[1:])
+    
+except Exception as e:
+    print("ERROR in wrapper: %s" % str(e), file=sys.stderr)
+    import traceback
+    traceback.print_exc(file=sys.stderr)
+    sys.exit(1)
+
+

--- a/gbplanner/scripts/spawn_robots.py
+++ b/gbplanner/scripts/spawn_robots.py
@@ -1,0 +1,156 @@
+#!/usr/bin/env python3
+"""
+Simple and stable robot spawner.
+Reads robot configuration from ROS parameters and spawns each robot using roslaunch subprocess.
+This approach is more stable than using the roslaunch API directly.
+"""
+
+import rospy
+import os
+import sys
+import subprocess
+import signal
+import time
+
+def spawn_robots():
+    """Spawn robots by reading config from rosparam and calling roslaunch for each."""
+    rospy.init_node('spawn_robots', anonymous=True)
+    
+    # Wait a moment for rosparam to load
+    rospy.sleep(0.5)
+    
+    # Get robot list from rosparam
+    try:
+        robots = rospy.get_param('robots_config/robots', [])
+    except KeyError:
+        rospy.logwarn("No robots config found, using default single robot")
+        robots = [{'name': 'rmf_obelix', 'base_name': 'rmf_obelix', 'x': 0.0, 'y': 0.0, 'z': 0.5}]
+    
+    if not robots:
+        rospy.logwarn("Empty robots list, using default single robot")
+        robots = [{'name': 'rmf_obelix', 'base_name': 'rmf_obelix', 'x': 0.0, 'y': 0.0, 'z': 0.5}]
+    
+    rospy.loginfo("Spawning %d robots", len(robots))
+    
+    # Wait for Gazebo to be ready before spawning robots
+    rospy.loginfo("Waiting for Gazebo to be ready...")
+    try:
+        rospy.wait_for_service('/gazebo/spawn_urdf_model', timeout=30.0)
+        rospy.loginfo("Gazebo is ready!")
+    except rospy.ROSException:
+        rospy.logwarn("Gazebo spawn service not available, but continuing anyway...")
+    
+    # Get global parameters
+    use_sim_time = rospy.get_param('/use_sim_time', True)
+    launch_prefix = rospy.get_param('~launch_prefix', '')
+    
+    # Store processes for cleanup
+    processes = []
+    
+    # Spawn each robot using roslaunch subprocess
+    for robot in robots:
+        robot_name = robot.get('name', 'robot')
+        base_name = robot.get('base_name', 'rmf_obelix')
+        robot_x = str(robot.get('x', 0.0))
+        robot_y = str(robot.get('y', 0.0))
+        robot_z = str(robot.get('z', 0.5))
+        
+        rospy.loginfo("Spawning robot: %s at (%s, %s, %s)", robot_name, robot_x, robot_y, robot_z)
+        
+        # Build roslaunch command
+        cmd = ['roslaunch', 'gbplanner', 'rmf_robot.launch',
+               'robot_name:=' + robot_name,
+               'base_name:=' + base_name,
+               'robot_x:=' + robot_x,
+               'robot_y:=' + robot_y,
+               'robot_z:=' + robot_z,
+               'use_sim_time:=' + str(use_sim_time)]
+        
+        if launch_prefix:
+            cmd.append('launch_prefix:=' + launch_prefix)
+        
+        try:
+            # Start roslaunch process
+            # Use Popen with proper environment to ensure ROS_MASTER_URI is set
+            env = os.environ.copy()
+            # Ensure ROS environment is sourced (PATH, ROS_PACKAGE_PATH, etc.)
+            # The subprocess should inherit the environment from the parent
+            rospy.loginfo("Launching robot %s with command: %s", robot_name, ' '.join(cmd))
+            # Don't pipe stdout/stderr - let them go to terminal so we can see what's happening
+            # This also prevents roslaunch from detecting it's in a non-interactive subprocess
+            process = subprocess.Popen(
+                cmd,
+                stdout=None,  # Don't capture - let it go to terminal
+                stderr=None,  # Don't capture - let it go to terminal
+                env=env,
+                preexec_fn=os.setsid  # Create new process group
+            )
+            processes.append((robot_name, process))
+            rospy.loginfo("Started robot %s (PID: %d)", robot_name, process.pid)
+            
+            # Longer delay between spawns to avoid Gazebo conflicts and segfaults
+            # Gazebo needs time to fully process each model before the next one
+            time.sleep(2.0)
+            
+        except Exception as e:
+            rospy.logerr("Error spawning robot %s: %s", robot_name, str(e))
+            continue
+    
+    if not processes:
+        rospy.logerr("No robots spawned!")
+        return
+    
+    rospy.loginfo("All %d robots spawned. Monitoring processes...", len(processes))
+    
+    # Monitor processes and keep node alive
+    def signal_handler(sig, frame):
+        """Handle shutdown signal."""
+        rospy.loginfo("Received shutdown signal, terminating robot processes...")
+        for robot_name, proc in processes:
+            try:
+                os.killpg(os.getpgid(proc.pid), signal.SIGTERM)
+            except:
+                pass
+        sys.exit(0)
+    
+    signal.signal(signal.SIGINT, signal_handler)
+    signal.signal(signal.SIGTERM, signal_handler)
+    
+    try:
+        rate = rospy.Rate(1)  # Check once per second
+        while not rospy.is_shutdown():
+            # Check if any process died unexpectedly
+            for robot_name, proc in processes:
+                if proc.poll() is not None:
+                    rospy.logwarn("Robot %s process exited with code %d", robot_name, proc.returncode)
+                    rospy.logwarn("Check the roslaunch logs for robot %s to see why it exited", robot_name)
+            rate.sleep()
+    except rospy.ROSInterruptException:
+        rospy.loginfo("Shutting down...")
+    finally:
+        # Cleanup: terminate all processes
+        rospy.loginfo("Terminating all robot processes...")
+        for robot_name, proc in processes:
+            try:
+                # Kill the process group
+                os.killpg(os.getpgid(proc.pid), signal.SIGTERM)
+                proc.wait(timeout=5)
+            except subprocess.TimeoutExpired:
+                rospy.logwarn("Force killing robot %s", robot_name)
+                try:
+                    os.killpg(os.getpgid(proc.pid), signal.SIGKILL)
+                except:
+                    pass
+            except Exception as e:
+                rospy.logwarn("Error terminating robot %s: %s", robot_name, str(e))
+
+if __name__ == '__main__':
+    try:
+        spawn_robots()
+    except KeyboardInterrupt:
+        pass
+    except Exception as e:
+        rospy.logerr("Fatal error: %s", str(e))
+        import traceback
+        traceback.print_exc()
+        sys.exit(1)

--- a/gbplanner_ui/src/gbplanner_ui.cpp
+++ b/gbplanner_ui/src/gbplanner_ui.cpp
@@ -1,23 +1,39 @@
 #include "gbplanner_ui.h"
+#include <ros/ros.h>
+#include <ros/master.h>
+#include <XmlRpcValue.h>
+#include <set>
+#include <string>
+#include <vector>
+#include <ros/this_node.h>
 // pci_initialization_trigger
 namespace gbplanner_ui {
 
-gbplanner_panel::gbplanner_panel(QWidget* parent) : rviz::Panel(parent) {
-  planner_client_start_planner = nh.serviceClient<std_srvs::Trigger>(
-      "/planner_control_interface/std_srvs/automatic_planning");
-  planner_client_stop_planner = nh.serviceClient<std_srvs::Trigger>(
-      "/planner_control_interface/std_srvs/stop");
-  planner_client_homing = nh.serviceClient<std_srvs::Trigger>(
-      "/planner_control_interface/std_srvs/homing_trigger");
-  planner_client_init_motion =
-      nh.serviceClient<planner_msgs::pci_initialization>(
-          "pci_initialization_trigger");
-  planner_client_plan_to_waypoint = nh.serviceClient<std_srvs::Trigger>(
-      "/planner_control_interface/std_srvs/go_to_waypoint");
-  planner_client_global_planner =
-      nh.serviceClient<planner_msgs::pci_global>("pci_global");
+gbplanner_panel::gbplanner_panel(QWidget* parent) : rviz::Panel(parent), selected_robot_name_("") {
+  // Discover available robots
+  discoverRobots();
 
   QVBoxLayout* v_box_layout = new QVBoxLayout;
+
+  // Robot selector
+  QHBoxLayout* robot_selector_layout = new QHBoxLayout;
+  robot_label = new QLabel("Robot:");
+  robot_selector = new QComboBox;
+  robot_selector->addItem("Select Robot...");
+  for (const auto& robot : available_robots_) {
+    robot_selector->addItem(QString::fromStdString(robot));
+  }
+  // If robots found, select first one by default
+  if (!available_robots_.empty()) {
+    robot_selector->setCurrentIndex(1);  // Index 0 is "Select Robot...", 1 is first robot
+    selected_robot_name_ = available_robots_[0];
+  }
+  robot_selector_layout->addWidget(robot_label);
+  robot_selector_layout->addWidget(robot_selector);
+  v_box_layout->addLayout(robot_selector_layout);
+
+  // Initialize service clients (will be updated when robot is selected)
+  updateServiceClients();
 
   button_start_planner = new QPushButton;
   button_stop_planner = new QPushButton;
@@ -65,9 +81,161 @@ gbplanner_panel::gbplanner_panel(QWidget* parent) : rviz::Panel(parent) {
           SLOT(on_plan_to_waypoint_click()));
   connect(button_global_planner, SIGNAL(clicked()), this,
           SLOT(on_global_planner_click()));
+  connect(robot_selector, SIGNAL(currentIndexChanged(int)), this,
+          SLOT(on_robot_selection_changed()));
+}
+
+void gbplanner_panel::discoverRobots() {
+  available_robots_.clear();
+  
+  // Method 1: Try to read from robots.yaml config via ROS parameters
+  XmlRpc::XmlRpcValue robots_config;
+  if (nh.getParam("/robots_config/robots", robots_config)) {
+    if (robots_config.getType() == XmlRpc::XmlRpcValue::TypeArray) {
+      for (int i = 0; i < robots_config.size(); ++i) {
+        if (robots_config[i].getType() == XmlRpc::XmlRpcValue::TypeStruct) {
+          if (robots_config[i].hasMember("name")) {
+            std::string robot_name = static_cast<std::string>(robots_config[i]["name"]);
+            available_robots_.push_back(robot_name);
+          }
+        }
+      }
+    }
+  }
+  
+  // Method 2: Discover by checking ROS services using master API
+  if (available_robots_.empty()) {
+    XmlRpc::XmlRpcValue request, response, payload;
+    request[0] = ros::this_node::getName();
+    if (ros::master::execute("getSystemState", request, response, payload, true)) {
+      // getSystemState returns: [code, statusMessage, [publishers, subscribers, services]]
+      if (payload.getType() == XmlRpc::XmlRpcValue::TypeArray && payload.size() >= 3) {
+        XmlRpc::XmlRpcValue services = payload[2];  // services is third element
+        if (services.getType() == XmlRpc::XmlRpcValue::TypeArray) {
+          std::set<std::string> found_robots;
+          for (int i = 0; i < services.size(); ++i) {
+            if (services[i].getType() == XmlRpc::XmlRpcValue::TypeArray && 
+                services[i].size() >= 1) {
+              std::string service_name = static_cast<std::string>(services[i][0]);
+              // Look for pattern: /robot_name/pci_initialization_trigger
+              size_t pos = service_name.find("/pci_initialization_trigger");
+              if (pos != std::string::npos && pos > 1) {
+                std::string robot_name = service_name.substr(1, pos - 1);  // Skip leading '/'
+                // Filter out common non-robot namespaces
+                if (robot_name != "planner_control_interface" && 
+                    robot_name != "gbplanner" && robot_name != "") {
+                  found_robots.insert(robot_name);
+                }
+              }
+            }
+          }
+          available_robots_.assign(found_robots.begin(), found_robots.end());
+        }
+      }
+    }
+  }
+  
+  // Method 3: Fallback - check for gbplanner services (including single-robot setups)
+  if (available_robots_.empty()) {
+    // Try to find any robot by checking for gbplanner services
+    ros::master::V_TopicInfo topics;
+    ros::master::getTopics(topics);
+    std::set<std::string> found_robots;
+    for (const auto& topic : topics) {
+      std::string name = topic.name;
+      // Look for pattern: /robot_name/gbplanner
+      size_t pos = name.find("/gbplanner");
+      if (pos != std::string::npos && pos > 1) {
+        std::string robot_name = name.substr(1, pos - 1);
+        // Accept any namespace that's not "gbplanner" itself
+        // This includes both single-robot (rmf_obelix) and multi-robot (rmf_obelix_1) names
+        if (robot_name != "gbplanner" && robot_name != "") {
+          found_robots.insert(robot_name);
+        }
+      }
+    }
+    available_robots_.assign(found_robots.begin(), found_robots.end());
+  }
+  
+  // Method 4: If still empty, try checking for pci services without underscore requirement
+  if (available_robots_.empty()) {
+    ros::master::V_TopicInfo topics;
+    ros::master::getTopics(topics);
+    std::set<std::string> found_robots;
+    for (const auto& topic : topics) {
+      std::string name = topic.name;
+      // Look for pattern: /robot_name/pci_initialization_trigger
+      size_t pos = name.find("/pci_initialization_trigger");
+      if (pos != std::string::npos && pos > 1) {
+        std::string robot_name = name.substr(1, pos - 1);
+        if (robot_name != "planner_control_interface" && robot_name != "") {
+          found_robots.insert(robot_name);
+        }
+      }
+    }
+    if (!found_robots.empty()) {
+      available_robots_.assign(found_robots.begin(), found_robots.end());
+    }
+  }
+  
+  ROS_INFO("[GBPLANNER-UI] Discovered %zu robots", available_robots_.size());
+  for (const auto& robot : available_robots_) {
+    ROS_INFO("[GBPLANNER-UI]   - %s", robot.c_str());
+  }
+}
+
+void gbplanner_panel::updateServiceClients() {
+  std::string robot_prefix = "";
+  if (!selected_robot_name_.empty()) {
+    robot_prefix = "/" + selected_robot_name_ + "/";
+  }
+  
+  // Update service clients with robot namespace
+  planner_client_start_planner = nh.serviceClient<std_srvs::Trigger>(
+      robot_prefix + "planner_control_interface/std_srvs/automatic_planning");
+  planner_client_stop_planner = nh.serviceClient<std_srvs::Trigger>(
+      robot_prefix + "planner_control_interface/std_srvs/stop");
+  planner_client_homing = nh.serviceClient<std_srvs::Trigger>(
+      robot_prefix + "planner_control_interface/std_srvs/homing_trigger");
+  planner_client_init_motion =
+      nh.serviceClient<planner_msgs::pci_initialization>(
+          robot_prefix + "pci_initialization_trigger");
+  planner_client_plan_to_waypoint = nh.serviceClient<std_srvs::Trigger>(
+      robot_prefix + "planner_control_interface/std_srvs/go_to_waypoint");
+  planner_client_global_planner =
+      nh.serviceClient<planner_msgs::pci_global>(robot_prefix + "pci_global");
+  
+  ROS_INFO("[GBPLANNER-UI] Updated service clients for robot: %s", 
+           selected_robot_name_.empty() ? "none" : selected_robot_name_.c_str());
+  ROS_INFO("[GBPLANNER-UI] Initialization service: %s", 
+           planner_client_init_motion.getService().c_str());
+}
+
+void gbplanner_panel::on_robot_selection_changed() {
+  int index = robot_selector->currentIndex();
+  if (index == 0) {
+    // "Select Robot..." selected
+    selected_robot_name_ = "";
+  } else {
+    selected_robot_name_ = available_robots_[index - 1];  // -1 because index 0 is "Select Robot..."
+  }
+  updateServiceClients();
+  ROS_INFO("[GBPLANNER-UI] Robot selection changed to: %s", 
+           selected_robot_name_.empty() ? "none" : selected_robot_name_.c_str());
 }
 
 void gbplanner_panel::on_start_planner_click() {
+  if (selected_robot_name_.empty()) {
+    ROS_ERROR("[GBPLANNER-UI] No robot selected! Please select a robot from the dropdown.");
+    return;
+  }
+  
+  if (!planner_client_start_planner.waitForExistence(ros::Duration(2.0))) {
+    ROS_ERROR("[GBPLANNER-UI] Service not available: %s", 
+              planner_client_start_planner.getService().c_str());
+    return;
+  }
+  
   std_srvs::Trigger srv;
   if (!planner_client_start_planner.call(srv)) {
     ROS_ERROR("[GBPLANNER-UI] Service call failed: %s",
@@ -76,6 +244,17 @@ void gbplanner_panel::on_start_planner_click() {
 }
 
 void gbplanner_panel::on_stop_planner_click() {
+  if (selected_robot_name_.empty()) {
+    ROS_ERROR("[GBPLANNER-UI] No robot selected! Please select a robot from the dropdown.");
+    return;
+  }
+  
+  if (!planner_client_stop_planner.waitForExistence(ros::Duration(2.0))) {
+    ROS_ERROR("[GBPLANNER-UI] Service not available: %s", 
+              planner_client_stop_planner.getService().c_str());
+    return;
+  }
+  
   std_srvs::Trigger srv;
   if (!planner_client_stop_planner.call(srv)) {
     ROS_ERROR("[GBPLANNER-UI] Service call failed: %s",
@@ -84,6 +263,17 @@ void gbplanner_panel::on_stop_planner_click() {
 }
 
 void gbplanner_panel::on_homing_click() {
+  if (selected_robot_name_.empty()) {
+    ROS_ERROR("[GBPLANNER-UI] No robot selected! Please select a robot from the dropdown.");
+    return;
+  }
+  
+  if (!planner_client_homing.waitForExistence(ros::Duration(2.0))) {
+    ROS_ERROR("[GBPLANNER-UI] Service not available: %s", 
+              planner_client_homing.getService().c_str());
+    return;
+  }
+  
   std_srvs::Trigger srv;
   if (!planner_client_homing.call(srv)) {
     ROS_ERROR("[GBPLANNER-UI] Service call failed: %s",
@@ -92,14 +282,47 @@ void gbplanner_panel::on_homing_click() {
 }
 
 void gbplanner_panel::on_init_motion_click() {
+  ROS_INFO("[GBPLANNER-UI] Initialization button clicked. Selected robot: '%s'", 
+           selected_robot_name_.empty() ? "NONE" : selected_robot_name_.c_str());
+  
+  if (selected_robot_name_.empty()) {
+    ROS_ERROR("[GBPLANNER-UI] No robot selected! Please select a robot from the dropdown.");
+    return;
+  }
+  
+  // Wait for service to be available
+  std::string service_name = planner_client_init_motion.getService();
+  ROS_INFO("[GBPLANNER-UI] Attempting to call service: %s", service_name.c_str());
+  
+  if (!planner_client_init_motion.waitForExistence(ros::Duration(2.0))) {
+    ROS_ERROR("[GBPLANNER-UI] Service not available: %s (timeout: 2s)", service_name.c_str());
+    ROS_ERROR("[GBPLANNER-UI] Make sure robot %s is running and pci_general_ros_node is started.", 
+              selected_robot_name_.c_str());
+    return;
+  }
+  
+  ROS_INFO("[GBPLANNER-UI] Service found, calling...");
   planner_msgs::pci_initialization srv;
   if (!planner_client_init_motion.call(srv)) {
-    ROS_ERROR("[GBPLANNER-UI] Service call failed: %s",
-              planner_client_init_motion.getService().c_str());
+    ROS_ERROR("[GBPLANNER-UI] Service call failed: %s", service_name.c_str());
+  } else {
+    ROS_INFO("[GBPLANNER-UI] Initialization triggered successfully for robot: %s", 
+             selected_robot_name_.c_str());
   }
 }
 
 void gbplanner_panel::on_plan_to_waypoint_click() {
+  if (selected_robot_name_.empty()) {
+    ROS_ERROR("[GBPLANNER-UI] No robot selected! Please select a robot from the dropdown.");
+    return;
+  }
+  
+  if (!planner_client_plan_to_waypoint.waitForExistence(ros::Duration(2.0))) {
+    ROS_ERROR("[GBPLANNER-UI] Service not available: %s", 
+              planner_client_plan_to_waypoint.getService().c_str());
+    return;
+  }
+  
   std_srvs::Trigger srv;
   if (!planner_client_plan_to_waypoint.call(srv)) {
     ROS_ERROR("[GBPLANNER-UI] Service call failed: %s",
@@ -134,6 +357,17 @@ void gbplanner_panel::on_global_planner_click() {
   // we got an ID!!!!!!!!!
   ROS_INFO("Global Planner found ID : %i", id);
 
+  if (selected_robot_name_.empty()) {
+    ROS_ERROR("[GBPLANNER-UI] No robot selected! Please select a robot from the dropdown.");
+    return;
+  }
+  
+  if (!planner_client_global_planner.waitForExistence(ros::Duration(2.0))) {
+    ROS_ERROR("[GBPLANNER-UI] Service not available: %s", 
+              planner_client_global_planner.getService().c_str());
+    return;
+  }
+  
   planner_msgs::pci_global plan_srv;
   plan_srv.request.id = id;
   if (!planner_client_global_planner.call(plan_srv)) {
@@ -143,9 +377,21 @@ void gbplanner_panel::on_global_planner_click() {
 }
 void gbplanner_panel::save(rviz::Config config) const {
   rviz::Panel::save(config);
+  config.mapSetValue("selected_robot", QString::fromStdString(selected_robot_name_));
 }
 void gbplanner_panel::load(const rviz::Config& config) {
   rviz::Panel::load(config);
+  QString saved_robot;
+  if (config.mapGetString("selected_robot", &saved_robot)) {
+    std::string robot_name = saved_robot.toStdString();
+    // Find and select the saved robot
+    int index = robot_selector->findText(saved_robot);
+    if (index >= 0) {
+      robot_selector->setCurrentIndex(index);
+      selected_robot_name_ = robot_name;
+      updateServiceClients();
+    }
+  }
 }
 
 }  // namespace gbplanner_ui

--- a/gbplanner_ui/src/gbplanner_ui.h
+++ b/gbplanner_ui/src/gbplanner_ui.h
@@ -9,8 +9,11 @@
 #include <std_msgs/ColorRGBA.h>
 #include <std_srvs/Empty.h>
 #include <std_srvs/Trigger.h>
+#include <string>
+#include <vector>
 
 #ifndef Q_MOC_RUN
+#include <QComboBox>
 #include <QHBoxLayout>
 #include <QLabel>
 #include <QLineEdit>
@@ -39,6 +42,7 @@ class gbplanner_panel : public rviz::Panel {
   void on_init_motion_click();
   void on_plan_to_waypoint_click();
   void on_global_planner_click();
+  void on_robot_selection_changed();
  protected Q_SLOTS:
 
  protected:
@@ -61,7 +65,16 @@ class gbplanner_panel : public rviz::Panel {
   QLineEdit* global_id_line_edit;
   ros::ServiceClient planner_client_global_planner;
 
+  QComboBox* robot_selector;
+  QLabel* robot_label;
+  std::string selected_robot_name_;
+
   ros::NodeHandle nh;
+
+ private:
+  void updateServiceClients();
+  void discoverRobots();
+  std::vector<std::string> available_robots_;
 };
 
 }  // namespace gbplanner_ui

--- a/planner_control_interface/src/planner_control_interface.cpp
+++ b/planner_control_interface/src/planner_control_interface.cpp
@@ -74,7 +74,7 @@ PlannerControlInterface::PlannerControlInterface(
 
   planner_set_trigger_mode_client_ =
       nh.serviceClient<planner_msgs::planner_set_planning_mode>(
-          "/gbplanner/set_planning_trigger_mode");
+          "gbplanner/set_planning_trigger_mode");  // Relative path - will be namespaced automatically
 
   pci_search_server_ = nh_.advertiseService(
       "pci_search", &PlannerControlInterface::searchCallback, this);
@@ -155,9 +155,9 @@ PlannerControlInterface::PlannerControlInterface(
     ros::shutdown();
   }
   // pci_manager_->initialize();
-  ROS_WARN_COND(global_verbosity >= Verbosity::WARN,
-                "[PCI]: Starting run() loop");
+  ROS_WARN("[PCI]: ===== CONSTRUCTOR: About to call run() loop =====");
   run();
+  ROS_ERROR("[PCI]: ===== ERROR: run() loop exited - this should never happen! =====");
 }
 
 void PlannerControlInterface::poseGoalCallback(
@@ -368,6 +368,7 @@ bool PlannerControlInterface::stdSrvSetHomingPositionHereCallback(
 bool PlannerControlInterface::initializationCallback(
     planner_msgs::pci_initialization::Request& req,
     planner_msgs::pci_initialization::Response& res) {
+  ROS_WARN("[PCI] Initialization callback called - setting init_request_ = true");
   init_request_ = true;
   res.success = true;
   return true;
@@ -510,8 +511,13 @@ bool PlannerControlInterface::init() {
   // Wait for the system is ready.
   // For example: checking odometry is ready.
   ros::Rate rr(1);
+  int wait_counter = 0;
   while (!pose_is_ready_) {
-    ROS_WARN_COND(global_verbosity >= Verbosity::DEBUG, "Waiting for odometry.");
+    wait_counter++;
+    // Log every 5 seconds (at 1Hz, that's every 5 iterations)
+    if (wait_counter % 5 == 0) {
+      ROS_WARN("[PCI] Still waiting for odometry... (waited %d seconds). Topic: /rmf_obelix_1/ground_truth/odometry_throttled", wait_counter);
+    }
     ros::spinOnce();
     rr.sleep();
   }
@@ -530,10 +536,27 @@ bool PlannerControlInterface::init() {
 }
 
 void PlannerControlInterface::run() {
+  ROS_WARN("[PCI] ===== RUN() LOOP STARTED =====");
   ros::Rate rr(10);  // 10Hz
   bool cont = true;
+  int loop_counter = 0;
   while (cont) {
+    loop_counter++;
     PCIManager::PCIStatus pci_status = pci_manager_->getStatus();
+    
+    // Debug logging every 100 loops (every 10 seconds at 10Hz)
+    if (loop_counter % 100 == 0) {
+      ROS_WARN("[PCI] Run loop: counter=%d, pci_status=%d (0=kReady), init_request_=%s, homing_request_=%s", 
+               loop_counter, (int)pci_status, init_request_ ? "true" : "false", homing_request_ ? "true" : "false");
+    }
+    
+    // Log immediately when init_request_ becomes true (don't wait for counter)
+    static bool last_init_request = false;
+    if (init_request_ && !last_init_request) {
+      ROS_WARN("[PCI] ===== init_request_ just became TRUE! pci_status=%d =====", (int)pci_status);
+    }
+    last_init_request = init_request_;
+    
     // TODO: Fix by prioritizing and sequencing exclusive cases (with bad
     // if/else and flags approach)
     if (pci_status == PCIManager::PCIStatus::kReady) {
@@ -549,8 +572,7 @@ void PlannerControlInterface::run() {
       // Priority 2: Check if require initialization step.
       else if (init_request_) {
         init_request_ = false;
-        ROS_INFO_COND(global_verbosity >= Verbosity::INFO,
-                      "PlannerControlInterface: Running Initialization");
+        ROS_WARN("[PCI] PlannerControlInterface: Running Initialization (init_request_ was true)");
         runInitialization();
         // Priority 3: Stop
       } else if (stop_planner_request_) {
@@ -590,8 +612,20 @@ void PlannerControlInterface::run() {
           runGlobalRepositioning();
       }
     } else if (pci_status == PCIManager::PCIStatus::kError) {
+      // Log error status periodically
+      static int error_log_counter = 0;
+      if (++error_log_counter % 100 == 0) {
+        ROS_ERROR("[PCI] Run loop: pci_status=kError (status=%d). Cannot process requests.", (int)pci_status);
+      }
       // For ANYmal, reset everything to manual then wait for operator.
       resetPlanner();
+    } else {
+      // Log other statuses (kRunning, kNotReady, etc.)
+      static int other_status_log_counter = 0;
+      if (++other_status_log_counter % 100 == 0) {
+        ROS_WARN("[PCI] Run loop: pci_status=%d (not kReady). init_request_=%s", 
+                 (int)pci_status, init_request_ ? "true" : "false");
+      }
     }
     cont = ros::ok();
     ros::spinOnce();
@@ -832,9 +866,18 @@ void PlannerControlInterface::runInitialization() {
   planner_msgs::planner_set_planning_mode planning_mode_srv;
   planning_mode_srv.request.planning_mode =
       planner_msgs::planner_set_planning_mode::Request::kManual;
-  planner_set_trigger_mode_client_.call(planning_mode_srv);
-
+  
+  std::string service_name = planner_set_trigger_mode_client_.getService();
+  ROS_WARN("[PCI] Calling service: %s", service_name.c_str());
+  
+  if (!planner_set_trigger_mode_client_.call(planning_mode_srv)) {
+    ROS_ERROR("[PCI] Failed to call service: %s", service_name.c_str());
+    return;
+  }
+  
+  ROS_WARN("[PCI] Successfully set planning mode to Manual");
   pci_manager_->initMotion();
+  ROS_WARN("[PCI] Initialization complete");
 }
 
 void PlannerControlInterface::runSearch(bool exe_path) {


### PR DESCRIPTION


Multi-Robot Support (Namespace-Safe)

Adds full multi-robot support to GBPlanner via proper namespace isolation and dynamic spawning from robots.yaml.

Key updates:

Fixed TF + topic namespacing (no double namespace issues)

Corrected pointcloud remap (relative paths inside namespace)

Fixed Gazebo plugins (robotNamespace, relative frameName)

Removed duplicate static TF publisher

Enabled global planner + added global_frame_id: world

Fixed service client paths for multi-robot UI control

Robots now spawn independently, publish isolated topics, and visualize correctly in RViz.
